### PR TITLE
fix: correct experimental commands

### DIFF
--- a/src/commands/experimental.ts
+++ b/src/commands/experimental.ts
@@ -10,8 +10,8 @@ export const experimental: CommandDefinition = {
         title: 'FlyByWire A32NX | Experimental Version',
         description: 'The experimental branch is now back in use! '
                 + 'This version is similar to the development version, but contains custom systems still being developed, including the new FBW Custom Flight Management System (cFMS). '
-                + 'Experimental version will be updated with the latest changes from both the "autopilot-custom-fpm" branch and development version regularly. '
-                + '\n> No support will be offered via Discord for this version. ',
+                + 'Experimental will be updated with the latest changes from both the "autopilot-custom-fpm" branch and development version regularly. '
+                + 'No support will be offered via Discord for this version. ',
         fields: [
             { name: 'Where can I download the Experimental version? ', value: '[Via the installer here](https://api.flybywiresim.com/installer)', inline: true },
         ],

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -12,13 +12,13 @@ export const versions: CommandDefinition = {
         fields: [
             {
                 name: 'Stable, Development or Experimental?',
-                value: '> The below has a brief explanation of the differences, for a more in depth explanation, [please click here.](https://docs.flybywiresim.com/start/fbw-versions) ',
+                value: '> You can find a brief explanation of the versions below, for a more in depth comparison, [please click here.](https://docs.flybywiresim.com/start/fbw-versions) ',
                 inline: false,
             },
             {
                 name: 'Stable',
-                value: '> Stable is our variant that has the least bugs and best performance. '
-                        + 'It will not always be up to date but we guarantee it\'s compatibility with each major patch from MSFS.'
+                value: '> Stable is our variant that has the fewest bugs and best performance. '
+                        + 'It will not always be up to date but we guarantee its compatibility with each major patch from MSFS.'
                         + '\n> Use the installer or [download here](https://api.flybywiresim.com/api/v1/download?url=https://flybywiresim-packages.b-cdn.net/stable/A32NX-stable.zip)',
                 inline: false,
             },

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -8,8 +8,13 @@ export const versions: CommandDefinition = {
     category: CommandCategory.FBW,
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'FlyByWire A32NX | Versions',
-        footer: { text: 'If you are having further problems, let us know in our #support channel. [More version info here](https://docs.flybywiresim.com/start/fbw-versions)' },
+        footer: { text: 'If you are having further problems, let us know in our #support channel.' },
         fields: [
+            {
+                name: 'Stable, Development or Experimental?',
+                value: '> The below has a brief explanation of the differences, for a more in depth explanation, [please click here.](https://docs.flybywiresim.com/start/fbw-versions) ',
+                inline: false,
+            },
             {
                 name: 'Stable',
                 value: '> Stable is our variant that has the least bugs and best performance. '

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -32,7 +32,7 @@ export const versions: CommandDefinition = {
             {
                 name: 'Experimental',
                 value: '> This version is similar to the development version, but contains custom systems still being developed, including the new FBW Custom Flight Management System (cFMS). '
-                        + 'Experimental version will be updated with the latest changes from both the "autopilot-custom-fpm" branch and development version regularly. '
+                        + 'Experimental will be updated with the latest changes from both the "autopilot-custom-fpm" branch and development version regularly. '
                         + '\n> No support will be offered via Discord for this version. '
                         + '\n> Use the installer or [download here](https://api.flybywiresim.com/api/v1/download?url=https://flybywiresim-packages.b-cdn.net/experimental/A32NX-experimental.zip)',
                 inline: false,

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -12,7 +12,7 @@ export const versions: CommandDefinition = {
         fields: [
             {
                 name: 'Stable, Development or Experimental?',
-                value: '> You can find a brief explanation of the versions below, for a more in depth comparison, [please click here.](https://docs.flybywiresim.com/start/fbw-versions) ',
+                value: '> You can find a brief explanation of the versions below, for a more in depth comparison, [please click here.](https://docs.flybywiresim.com/fbw-a32nx/fbw-versions) ',
                 inline: false,
             },
             {


### PR DESCRIPTION
PR to make slight changes to .exp and .versions currently in staging based on testing commands. 

Footer doesn't support embed - request as per https://github.com/flybywiresim/discord-bot/issues/8#issuecomment-894810549 was to link to versions, moved to own small section to give clarity to that and removed the link part entirely from the footer.

![image](https://user-images.githubusercontent.com/87286435/130331792-47ee5b57-a703-458e-8f3c-f1737756242c.png)

After testing in staging, the split on the "no support" line just makes the command messy and takes up more space than necessary, reformed to pull into the main text. Also removed "version" from following as "Experimental ---- will be updated with the latest changes from both the "autopilot-custom-fpm" branch and development version regularly." reads better when referring to the version by name.

![image](https://user-images.githubusercontent.com/87286435/130331815-63c4021b-d6fc-4814-9b53-6de660bd7944.png)

Created a new updated fork removing old one, and created PR on a new branch as per suggestions by BenW rather than on staging as done for the last PR.
