### PR TITLE
fix: remove "mod" from .trythis

### DIFF
--- a/src/commands/trythis.ts
+++ b/src/commands/trythis.ts
@@ -8,7 +8,7 @@ export const trythis: CommandDefinition = {
     category: CommandCategory.FBW,
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'Try This',
-        description: 'Please try and remove all other mods/liveries from the community folder and test our mod again. This will help rule out mod conflicts.',
+        description: 'Please try and remove all other mods/liveries from the community folder and test our addon again. This will help rule out mod conflicts.',
         footer: { text: 'Report back the result of this test.' },
     })),
 };


### PR DESCRIPTION
Replaces "mod" with "addon" when referring to the A32NX.