### PR TITLE
feat: add .screenshot, add .msfs + fixes

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -24,6 +24,7 @@ import { donate } from './donate';
 import { utf8 } from './utf-8';
 import { calibrate } from './calibrate';
 import { nut } from './nut';
+import { screenshot} from './screenshot';
 import { CommandDefinition } from '../lib/command';
 import Logger from '../lib/logger';
 
@@ -54,6 +55,7 @@ const commands: CommandDefinition[] = [
     utf8,
     calibrate,
     nut,
+    screenshot,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -24,7 +24,8 @@ import { donate } from './donate';
 import { utf8 } from './utf-8';
 import { calibrate } from './calibrate';
 import { nut } from './nut';
-import { screenshot} from './screenshot';
+import { screenshot } from './screenshot';
+import { msfs } from './msfs';
 import { CommandDefinition } from '../lib/command';
 import Logger from '../lib/logger';
 
@@ -56,6 +57,7 @@ const commands: CommandDefinition[] = [
     calibrate,
     nut,
     screenshot,
+    msfs,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};

--- a/src/commands/installer.ts
+++ b/src/commands/installer.ts
@@ -9,7 +9,7 @@ export const installer: CommandDefinition = {
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'Installer',
         description: 'Download the new A32NX Installer where you can select either the Stable, Developer or an Experimental Version, '
-            + 'and download and install the mod directly into your Community Folder, [download here](https://api.flybywiresim.com/installer)',
+            + 'and download and install the addon directly into your Community Folder, [download here](https://api.flybywiresim.com/installer)',
         footer: { text: 'If you are having further problems, let us know in our Support Channel and we will provide more assistance.' },
     })),
 };

--- a/src/commands/msfs.ts
+++ b/src/commands/msfs.ts
@@ -1,0 +1,13 @@
+import { CommandDefinition } from '../lib/command';
+import { CommandCategory } from '../constants';
+import { makeEmbed } from '../lib/embed';
+
+export const msfs: CommandDefinition = {
+    name: ['msfs', 'msfsforum'],
+    description: 'Provides links to MSFS support for sim issues',
+    category: CommandCategory.FBW,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'FlyByWire Support | Sim issues',
+        description: 'This is the FlyByWire Support channel, and we\'re only able to help with issues with our aircraft. For any core Microsoft Flight Simulator related issues please ask on [Microsoft Flight Simulator\'s Discord](https://discord.gg/FZKDaVst) or in the official [Microsoft Flight Simulator Forum](https://forums.flightsimulator.com/c/community/140).',
+    })),
+};

--- a/src/commands/screenshot.ts
+++ b/src/commands/screenshot.ts
@@ -12,7 +12,7 @@ export const screenshot: CommandDefinition = {
         title: 'FlyByWire Support | How to take a good screenshot',
         description: makeLines([
             'Position yourself in the cockpit using the arrow keys to look straight at the front instrument panel.'
-           + 'Then use the Windows Sniping Tool to take a clear screenshot of all screens and the FCU as shown.',
+           + 'Then use the Windows Snipping Tool to take a clear screenshot of all screens and the FCU as shown.',
              'Please read the guide [here](https://docs.flybywiresim.com/fbw-a32nx/support/#screenshot-of-cockpit) for more information. ',
         ]),
         image: { url: SCREENSHOT_HELP_URL },

--- a/src/commands/screenshot.ts
+++ b/src/commands/screenshot.ts
@@ -11,7 +11,7 @@ export const screenshot: CommandDefinition = {
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'FlyByWire Support | How to take a good screenshot',
         description: makeLines([
-            'Position yourself in the cockpit using the arrow keys to look straight at the front instrument panel.'
+            'Position yourself in the cockpit using the arrow keys to look straight at the front instrument panel. '
            + 'Then use the Windows Snipping Tool to take a clear screenshot of all screens and the FCU as shown.',
              'Please read the guide [here](https://docs.flybywiresim.com/fbw-a32nx/support/#screenshot-of-cockpit) for more information. ',
         ]),

--- a/src/commands/screenshot.ts
+++ b/src/commands/screenshot.ts
@@ -1,0 +1,20 @@
+import { CommandDefinition } from '../lib/command';
+import { makeEmbed, makeLines } from '../lib/embed';
+import { CommandCategory } from '../constants';
+
+const SCREENSHOT_HELP_URL = 'https://docs.flybywiresim.com/fbw-a32nx/assets/support-guide/cockpit-screenshot.jpg';
+
+export const screenshot: CommandDefinition = {
+    name: ['screenshot', 'cockpit'],
+    description: 'Help to screenshot for support',
+    category: CommandCategory.FBW,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'FlyByWire Support | How to take a good screenshot',
+        description: makeLines([
+            'Position yourself in the cockpit using the arrow keys to look straight at the front instrument panel.'
+           + 'Then use the Windows Sniping Tool to take a clear screenshot of all screens and the FCU as shown.',
+             'Please read the guide [here](https://docs.flybywiresim.com/fbw-a32nx/support/#screenshot-of-cockpit) for more information. ',
+        ]),
+        image: { url: SCREENSHOT_HELP_URL },
+    })),
+};

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -17,15 +17,17 @@ export const versions: CommandDefinition = {
             },
             {
                 name: 'Stable',
-                value: '> Stable is our variant that has the fewest bugs and best performance. '
-                        + 'It will not always be up to date but we guarantee its compatibility with each major patch from MSFS.'
+                value: '> Stable is our version which has features that are the most mature and most tested. '
+                        + 'This should be a reliable version for the more conservative user preferring stability over newest features. '
+                        + 'Will be compatible with each major MSFS patch.'
                         + '\n> Use the installer or [download here](https://api.flybywiresim.com/api/v1/download?url=https://flybywiresim-packages.b-cdn.net/stable/A32NX-stable.zip)',
                 inline: false,
             },
             {
                 name: 'Development',
-                value: '> Development will have the latest features that will end up in the next stable. '
-                        + 'Bugs are to be expected. It updates whenever something is added to the \'master\' branch on Github.'
+                value: '> Development will have the latest features that will eventually end up in the next stable release. '
+                        + 'In general this version has the latest fixes and newest features but also a slightly higher risk of containing bugs. '
+                        + 'Development updates whenever a change is made to the "master" branch on Github. '
                         + '\n> Use the installer or [download here](https://api.flybywiresim.com/api/v1/download?url=https://flybywiresim-packages.b-cdn.net/vmaster/A32NX-master.zip)',
                 inline: false,
             },

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -18,7 +18,7 @@ export const versions: CommandDefinition = {
             {
                 name: 'Stable',
                 value: '> Stable is our version which has features that are the most mature and most tested. '
-                        + 'This should be a reliable version for the more conservative user preferring stability over newest features. '
+                        + 'This should be a reliable version for those preferring stability over newest features. '
                         + 'Will be compatible with each major MSFS patch.'
                         + '\n> Use the installer or [download here](https://api.flybywiresim.com/api/v1/download?url=https://flybywiresim-packages.b-cdn.net/stable/A32NX-stable.zip)',
                 inline: false,


### PR DESCRIPTION
- .installer still referenced the A32NX as 'mod', replaced with 'addon'. 
- .versions had outdated content for the Stable and Development sections, mentioned after updating the experimental section, updated these parts based on feedback.
- Added .versions as per https://github.com/flybywiresim/discord-bot/issues/8#issuecomment-894810549 - responds to .screenshot and .cockpit
- Added .msfs as per the same issue - directs to MSFS forums and discord - usable with .msfs and .msfsforum

Testbot results as below:

![image](https://user-images.githubusercontent.com/87286435/131235465-db1149c2-ff4c-4a75-9a76-6b4341f1fdb6.png)

![image](https://user-images.githubusercontent.com/87286435/131234690-d4cff37e-a63f-4449-af9d-5c705af56e25.png)

![image](https://user-images.githubusercontent.com/87286435/131232307-c31090f0-2f36-49f9-abea-f75593738ce7.png)

![image](https://user-images.githubusercontent.com/87286435/131232311-9bd5dedb-d637-4385-b775-e1375fbb3d93.png)
