### PR TITLE
feat: add .content

### DIFF
--- a/src/commands/content.ts
+++ b/src/commands/content.ts
@@ -1,0 +1,19 @@
+import { CommandDefinition } from '../lib/command';
+import { makeEmbed, makeLines } from '../lib/embed';
+import { CommandCategory } from '../constants';
+
+const CONTENTMANAGER_HELP_URL = 'https://docs.flybywiresim.com/fbw-a32nx/assets/support-guide/Content-Manager.jpg';
+
+export const content: CommandDefinition = {
+    name: ['content', 'contentmanager'],
+    description: 'Help to identify aircraft version for support',
+    category: CommandCategory.FBW,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'FlyByWire Support | Checking your aircraft version',
+        description: makeLines([
+            'In order to check which version of the A32NX you have installed, please open the MSFS Content Manager from the second page on the main menu and search for \'A32NX\'. '
+          + 'Then take a screenshot showing the results and send it here in [#Support](https://discord.gg/U2Askt6r) as shown below. ',
+        ]),
+        image: { url: CONTENTMANAGER_HELP_URL },
+    })),
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -27,6 +27,7 @@ import { controls } from './controls';
 import { nut } from './nut';
 import { screenshot } from './screenshot';
 import { msfs } from './msfs';
+import { content } from './content';
 import { CommandDefinition } from '../lib/command';
 import Logger from '../lib/logger';
 
@@ -60,6 +61,7 @@ const commands: CommandDefinition[] = [
     nut,
     screenshot,
     msfs,
+    content,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};


### PR DESCRIPTION
Adds .content (also takes .contentmanager) to request a screenshot showing the sims content manager, and explain how. 

Test bot results:

![image](https://user-images.githubusercontent.com/87286435/131940174-641ceb9e-195e-4ca2-b0c7-cc517cf6f3b2.png)
