### PR TITLE
feat: added .briefing

### DIFF
--- a/src/commands/briefing.ts
+++ b/src/commands/briefing.ts
@@ -1,0 +1,13 @@
+import { CommandDefinition } from '../lib/command';
+import { CommandCategory } from '../constants';
+import { makeEmbed } from '../lib/embed';
+
+export const briefing: CommandDefinition = {
+    name: 'briefing',
+    description: 'Provides a link to the A320neo Pilot Briefing',
+    category: CommandCategory.FBW,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'FlyByWire A32NX | A320neo Pilot Briefing',
+        description: 'Please see our [A320neo Pilot Briefing](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/) for an interactive overview of the flight deck and systems. (This is work in progress and we will add more chapters over time).',
+    })),
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -28,6 +28,7 @@ import { nut } from './nut';
 import { screenshot } from './screenshot';
 import { msfs } from './msfs';
 import { content } from './content';
+import { briefing } from './briefing';
 import { CommandDefinition } from '../lib/command';
 import Logger from '../lib/logger';
 
@@ -62,6 +63,7 @@ const commands: CommandDefinition[] = [
     screenshot,
     msfs,
     content,
+    briefing,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};


### PR DESCRIPTION
This command provides a link to the A320neo Pilot Briefing on the FBW docs site.

Bot preview:
![image](https://user-images.githubusercontent.com/67422707/132408342-44894d6b-7ee2-4350-9f71-55a16fd71989.png)

Discord username: BenW#8484