### PR TITLE
feat: add .boris gif

### DIFF
--- a/src/commands/boris.ts
+++ b/src/commands/boris.ts
@@ -1,0 +1,12 @@
+import { CommandDefinition } from '../lib/command';
+import { makeEmbed } from '../lib/embed';
+import { CommandCategory } from '../constants';
+
+const BORIS_URL = 'https://c.tenor.com/1bIsb5roaSsAAAAd/haggisbandit-sound.gif';
+
+export const boris: CommandDefinition = {
+    name: 'boris',
+    description: 'boris soudn',
+    category: CommandCategory.FBW,
+    executor: (msg) => msg.channel.send(makeEmbed({ image: { url: BORIS_URL } })),
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -30,6 +30,7 @@ import { msfs } from './msfs';
 import { content } from './content';
 import { beginner } from './beginner-guide';
 import { briefing } from './briefing';
+import { boris } from './boris';
 import { CommandDefinition } from '../lib/command';
 import Logger from '../lib/logger';
 
@@ -66,6 +67,7 @@ const commands: CommandDefinition[] = [
     content,
     beginner,
     briefing,
+    boris,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};


### PR DESCRIPTION
This PR adds a .boris command, calling the GIF [here](https://c.tenor.com/1bIsb5roaSsAAAAd/haggisbandit-sound.gif), a fun one for the server memes similar to .bruheg and .nut.

Built and tested, test results as shown:

![image](https://user-images.githubusercontent.com/87286435/132901687-ff23d488-302a-4e46-b0a5-e2ebfc13c1ec.png)

Discord username: █▀█ █▄█ ▀█▀#2123

