### PR TITLE
fix: update .content command

### DIFF
--- a/src/commands/content.ts
+++ b/src/commands/content.ts
@@ -12,7 +12,7 @@ export const content: CommandDefinition = {
         title: 'FlyByWire Support | Checking your aircraft version',
         description: makeLines([
             'In order to check which version of the A32NX you have installed, please open the MSFS Content Manager from the second page on the main menu and search for \'flybywire\'. '
-          + 'Then take a screenshot showing the results and send it here in [#Support](https://discord.gg/U2Askt6r) as shown below. ',
+          + 'Then take a screenshot showing the results and send it here in [#Support](https://discord.gg/tJebFgXrUX) as shown below. ',
             '',
             'If you find old versions or multiple installations, please delete them via the Content Manager and/or your Community folder.',
         ]),

--- a/src/commands/content.ts
+++ b/src/commands/content.ts
@@ -13,6 +13,8 @@ export const content: CommandDefinition = {
         description: makeLines([
             'In order to check which version of the A32NX you have installed, please open the MSFS Content Manager from the second page on the main menu and search for \'A32NX\'. '
           + 'Then take a screenshot showing the results and send it here in [#Support](https://discord.gg/U2Askt6r) as shown below. ',
+            '',
+            'If you find old versions or multiple installations, please delete them via the Content Manager and/or your Community folder.',
         ]),
         image: { url: CONTENTMANAGER_HELP_URL },
     })),

--- a/src/commands/content.ts
+++ b/src/commands/content.ts
@@ -12,7 +12,7 @@ export const content: CommandDefinition = {
         title: 'FlyByWire Support | Checking your aircraft version',
         description: makeLines([
             'In order to check which version of the A32NX you have installed, please open the MSFS Content Manager from the second page on the main menu and search for \'flybywire\'. '
-          + 'Then take a screenshot showing the results and send it here in [#Support](https://discord.gg/tJebFgXrUX) as shown below. ',
+          + 'Then take a screenshot showing the results and send it here in <#785976111875751956> as shown below. ',
             '',
             'If you find old versions or multiple installations, please delete them via the Content Manager and/or your Community folder.',
         ]),

--- a/src/commands/content.ts
+++ b/src/commands/content.ts
@@ -2,7 +2,7 @@ import { CommandDefinition } from '../lib/command';
 import { makeEmbed, makeLines } from '../lib/embed';
 import { CommandCategory } from '../constants';
 
-const CONTENTMANAGER_HELP_URL = 'https://docs.flybywiresim.com/fbw-a32nx/assets/support-guide/Content-Manager.jpg';
+const CONTENTMANAGER_HELP_URL = 'https://media.discordapp.net/attachments/740722295009706034/885966763089625088/unknown.png';
 
 export const content: CommandDefinition = {
     name: ['content', 'contentmanager'],

--- a/src/commands/content.ts
+++ b/src/commands/content.ts
@@ -11,7 +11,7 @@ export const content: CommandDefinition = {
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'FlyByWire Support | Checking your aircraft version',
         description: makeLines([
-            'In order to check which version of the A32NX you have installed, please open the MSFS Content Manager from the second page on the main menu and search for \'A32NX\'. '
+            'In order to check which version of the A32NX you have installed, please open the MSFS Content Manager from the second page on the main menu and search for \'flybywire\'. '
           + 'Then take a screenshot showing the results and send it here in [#Support](https://discord.gg/U2Askt6r) as shown below. ',
             '',
             'If you find old versions or multiple installations, please delete them via the Content Manager and/or your Community folder.',


### PR DESCRIPTION
This PR updates the image used for .content as per discussions on Discord, and adds a sentence clarifying old/duplicate installs should be deleted.

Test results:
![image](https://user-images.githubusercontent.com/87286435/132906219-5f4d815d-0088-463b-9635-8075c273443e.png)

Discord username: █▀█ █▄█ ▀█▀#2123