### PR TITLE
feat: add simbrief airframe command 

### DIFF
--- a/src/commands/airframe.ts
+++ b/src/commands/airframe.ts
@@ -1,0 +1,13 @@
+import { CommandDefinition } from '../lib/command';
+import { CommandCategory } from '../constants';
+import { makeEmbed } from '../lib/embed';
+
+export const airframe: CommandDefinition = {
+    name: ['airframe', 'simbrief'],
+    description: 'Provides a link to the updated Simbrief airframe',
+    category: CommandCategory.FBW,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'FlyByWire A32NX | Simbrief Airframe',
+        description: 'Our updated Simbrief airframe for the A32NX with correct weights is available [here](https://www.simbrief.com/system/dispatch.php?sharefleet=337364_1631550522735). This is a new airframe based on our updated flight model, and will always be kept up-to-date.'
+    })),
+};

--- a/src/commands/airframe.ts
+++ b/src/commands/airframe.ts
@@ -7,7 +7,7 @@ export const airframe: CommandDefinition = {
     description: 'Provides a link to the updated Simbrief airframe',
     category: CommandCategory.FBW,
     executor: (msg) => msg.channel.send(makeEmbed({
-        title: 'FlyByWire A32NX | Simbrief Airframe',
-        description: 'Our updated Simbrief airframe for the A32NX with correct weights is available [here](https://www.simbrief.com/system/dispatch.php?sharefleet=337364_1631550522735). This is a new airframe based on our updated flight model, and will always be kept up-to-date.'
+        title: 'FlyByWire A32NX | SimBrief Airframe',
+        description: 'Our updated SimBrief airframe for the A32NX with correct weights is available [here](https://www.simbrief.com/system/dispatch.php?sharefleet=337364_1631550522735). This is a new airframe based on our updated flight model, and will always be kept up-to-date.'
     })),
 };

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -32,6 +32,7 @@ import { beginner } from './beginner-guide';
 import { briefing } from './briefing';
 import { boris } from './boris';
 import { afloor } from './afloor';
+import { airframe } from './airframe';
 import { CommandDefinition } from '../lib/command';
 import Logger from '../lib/logger';
 
@@ -70,6 +71,7 @@ const commands: CommandDefinition[] = [
     briefing,
     boris,
     afloor,
+    airframe,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};


### PR DESCRIPTION
Adds a command to share the new simbrief airframe link, responds to .simbrief and .airframe. 

Results:
![image](https://user-images.githubusercontent.com/87286435/133892145-664f1ea8-ed8d-40ed-9ec9-4ce5468ef5d6.png)


Discord: █▀█ █▄█ ▀█▀#2123