### PR TITLE
fix: unban permissions

### DIFF
--- a/src/commands/unban.ts
+++ b/src/commands/unban.ts
@@ -7,6 +7,7 @@ type UserLike = User | Snowflake
 
 export const unban: CommandDefinition = {
     name: 'unban',
+    requiredPermissions: ['BAN_MEMBERS'],
     category: CommandCategory.MODERATION,
     executor: (msg) => {
         const splitUp = msg.content.replace(/\.unban\s+/, '').split(' ');


### PR DESCRIPTION
## Description

Fixes the unban permissions, anyone could unban before. You now need to hold the 'ban members' Discord permission to use .unban.

## Test Results

I had the permissions, Nut did not. Working as expected.

![image](https://user-images.githubusercontent.com/67422707/134068301-211a5510-62a1-429d-94ae-b9015a4fedac.png)

## Discord Username

BenW#8484