### PR TITLE
fix: rename command utf8

### DIFF
--- a/src/commands/utf-8.ts
+++ b/src/commands/utf-8.ts
@@ -3,7 +3,7 @@ import { CommandCategory } from '../constants';
 import { makeEmbed, makeLines } from '../lib/embed';
 
 export const utf8: CommandDefinition = {
-    name: 'utf',
+    name: 'utf8',
     description: 'Provides a link to resolve UTF-8 issues',
     category: CommandCategory.FBW,
     executor: (msg) => msg.channel.send(makeEmbed({


### PR DESCRIPTION
Updates the alias of the UTF8 command from .utf to .utf8 - small change but keeps catching people out. 

Tested, results: 
![image](https://user-images.githubusercontent.com/87286435/134571363-cb728a27-8d79-4f9e-bdb6-58326b8895fa.png)

Discord username: █▀█ █▄█ ▀█▀#2123