### PR TITLE
fix: change airframe link to docs

### DIFF
--- a/src/commands/airframe.ts
+++ b/src/commands/airframe.ts
@@ -8,6 +8,6 @@ export const airframe: CommandDefinition = {
     category: CommandCategory.FBW,
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'FlyByWire A32NX | SimBrief Airframe',
-        description: 'Our updated SimBrief airframe for the A32NX with correct weights is available [here](https://www.simbrief.com/system/dispatch.php?sharefleet=337364_1631550522735). This is a new airframe based on our updated flight model, and will always be kept up-to-date.'
+        description: 'Our updated SimBrief airframe for the A32NX with correct weights is available [here](https://docs.flybywiresim.com/fbw-a32nx/installation/#simbrief-airframe). This is a new airframe based on our updated flight model, and will always be kept up-to-date.'
     })),
 };


### PR DESCRIPTION
Replaces the link to the simbrief airframe with the docs page containing both simbrief links rather than the link directly. 

Tested, link directs correctly to the docs page: https://docs.flybywiresim.com/fbw-a32nx/installation/#simbrief-airframe

![image](https://user-images.githubusercontent.com/87286435/134572834-f9976253-0f66-4764-a643-a25c79c5cc14.png)

Discord username: █▀█ █▄█ ▀█▀#2123

