### PR TITLE
fix: reword .msfs to make sense in all channels

### DIFF
--- a/src/commands/msfs.ts
+++ b/src/commands/msfs.ts
@@ -8,6 +8,6 @@ export const msfs: CommandDefinition = {
     category: CommandCategory.FBW,
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'MSFS | Sim issues',
-        description: 'This is the FlyByWire Support channel, and we\'re only able to help with issues with our aircraft. For any core Microsoft Flight Simulator related issues please ask on [Microsoft Flight Simulator\'s Discord](https://discord.gg/msfs) or in the official [Microsoft Flight Simulator Forum](https://forums.flightsimulator.com/c/community/140).',
+        description: 'This is the FlyByWire Discord server, and we\'re only able to help with issues with our aircraft. For any core Microsoft Flight Simulator related issues please ask on [Microsoft Flight Simulator\'s Discord](https://discord.gg/msfs) or in the official [Microsoft Flight Simulator Forum](https://forums.flightsimulator.com/c/community/140).',
     })),
 };


### PR DESCRIPTION
Slightly rewords the .msfs command to state "This is the FlyByWire Discord Server" rather than "Support channel" as the command is often used in other channels and doesn't make much sense.

Test results:
![image](https://user-images.githubusercontent.com/87286435/134573365-f123e971-1a76-4224-9b64-39a450f52d07.png)

Discord: █▀█ █▄█ ▀█▀#2123