### PR TITLE
feat: add .willithave command

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -34,6 +34,7 @@ import { boris } from './boris';
 import { afloor } from './afloor';
 import { airframe } from './airframe';
 import { xbox } from './xbox';
+import { willithave } from './willithave';
 import { CommandDefinition } from '../lib/command';
 import Logger from '../lib/logger';
 
@@ -74,6 +75,7 @@ const commands: CommandDefinition[] = [
     afloor,
     airframe,
     xbox,
+    willithave,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};

--- a/src/commands/willithave.ts
+++ b/src/commands/willithave.ts
@@ -1,0 +1,16 @@
+import { CommandDefinition } from '../lib/command';
+import { CommandCategory } from '../constants';
+import { makeEmbed, makeLines } from '../lib/embed';
+
+export const willithave: CommandDefinition = {
+    name: ['thumb', 'willithave'],
+    description: 'Answers the big question, will it have FEATURE?',
+    category: CommandCategory.FBW,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'Will the aircraft have [FEATURE]?',
+        description: makeLines(['The FBW rule of thumb is:',
+                ,
+                'If it\'s in the real aircraft, it\'ll be there.',
+        ]),
+    })),
+};


### PR DESCRIPTION
Adds the FBW rule of thumb as suggested by Holland in discord, general answer all to feature questions. 

Responds to .willithave and .thumb (I liked that). 

Results: 
![image](https://user-images.githubusercontent.com/87286435/134672352-5a68ec57-5942-48aa-862c-b6c49f55c519.png)

Discord: █▀█ █▄█ ▀█▀#2123