### PR TITLE
fix: update .afloor

### DIFF
--- a/src/commands/afloor.ts
+++ b/src/commands/afloor.ts
@@ -8,6 +8,6 @@ export const afloor: CommandDefinition = {
     category: CommandCategory.FBW,
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'FlyByWire A32NX | Alpha Floor',
-        description: 'Please see our [Alpha Floor Protection Tool-Tip](https://youtu.be/iXQb675J9mA) for information on Alpha Floor Protection and how to prevent/recover from it.',
+        description: 'Please see our [Alpha Floor Protection Guide](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/afloor/) or [Video Tool-Tip](https://youtu.be/iXQb675J9mA) for information on Alpha Floor Protection and how to prevent/recover from it.',
     })),
 };


### PR DESCRIPTION
Adds new alpha floor docs to the bot command .afloor alongside video tooltip

Results:
![image](https://user-images.githubusercontent.com/87286435/134672814-7201967e-6b38-4118-8ce5-06ed1730a688.png)

Discord username:  █▀█ █▄█ ▀█▀#2123