### PR TITLE
feat: add .community command to locate com folder

### DIFF
--- a/src/commands/community.ts
+++ b/src/commands/community.ts
@@ -13,9 +13,9 @@ export const community: CommandDefinition = {
         description: makeLines([
             'To find the Community folder that MSFS is using please follow these steps:',
             ,
-            '1. Go to General Settings in MSFS and activate \'Developer Mode\'.',
+            '1. Go to General Settings in MSFS and activate Developer Mode.',
             '2. Go to the menu and open the Virtual File System.',
-            '3. Click on Packages Folders and select "Open Community Folder".',
+            '3. Click on \'Packages Folders\' and select \'Open Community Folder\'.',
             ,
             'This opens the Community folder in a Windows Explorer.',
         ]),

--- a/src/commands/community.ts
+++ b/src/commands/community.ts
@@ -1,0 +1,25 @@
+import { CommandDefinition } from '../lib/command';
+import { makeEmbed, makeLines } from '../lib/embed';
+import { CommandCategory } from '../constants';
+
+const COMFOLDER_HELP_URL = 'https://docs.flybywiresim.com/fbw-a32nx/assets/find-community-folder.png';
+
+export const community: CommandDefinition = {
+    name: ['community', 'com'],
+    description: 'Help to identify community folder for support',
+    category: CommandCategory.FBW,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'FlyByWire Support | Identifying your Community folder',
+        description: makeLines([
+            'To find the Community folder that MSFS is using please follow these steps:',
+            ,
+            '1. Go to General Settings in MSFS and activate \'Developer Mode.\'',
+            '2. Go to the menu and open the Virtual File System.',
+            '3. Click on Packages Folders and select "Open Community Folder".',
+            ,
+            'This opens the Community folder in a Windows Explorer.',
+        ]),
+        image: { url: COMFOLDER_HELP_URL },
+        footer: { text: 'Tip: Click the image to view in full size' }
+    })),
+};

--- a/src/commands/community.ts
+++ b/src/commands/community.ts
@@ -13,7 +13,7 @@ export const community: CommandDefinition = {
         description: makeLines([
             'To find the Community folder that MSFS is using please follow these steps:',
             ,
-            '1. Go to General Settings in MSFS and activate \'Developer Mode.\'',
+            '1. Go to General Settings in MSFS and activate \'Developer Mode\'.',
             '2. Go to the menu and open the Virtual File System.',
             '3. Click on Packages Folders and select "Open Community Folder".',
             ,

--- a/src/commands/community.ts
+++ b/src/commands/community.ts
@@ -17,7 +17,7 @@ export const community: CommandDefinition = {
             '2. Go to the menu and open the Virtual File System.',
             '3. Click on \'Packages Folders\' and select \'Open Community Folder\'.',
             ,
-            'This opens the Community folder in a Windows Explorer.',
+            'This opens the Community folder in a Windows Explorer. Please ensure that your addons are installed in the folder that is opened. ',
         ]),
         image: { url: COMFOLDER_HELP_URL },
         footer: { text: 'Tip: Click the image to view in full size' }

--- a/src/commands/community.ts
+++ b/src/commands/community.ts
@@ -14,7 +14,7 @@ export const community: CommandDefinition = {
             'To find the Community folder that MSFS is using please follow these steps:',
             ,
             '1. Go to General Settings in MSFS and activate Developer Mode.',
-            '2. Go to the menu and open the Virtual File System.',
+            '2. Go to the menu and select \'Virtual File System\'.',
             '3. Click on \'Packages Folders\' and select \'Open Community Folder\'.',
             ,
             'This opens the Community folder in a Windows Explorer. Please ensure that your addons are installed in the folder that is opened. ',

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -36,6 +36,7 @@ import { airframe } from './airframe';
 import { xbox } from './xbox';
 import { willithave } from './willithave';
 import { faq } from './faq';
+import { community } from './community';
 import { CommandDefinition } from '../lib/command';
 import Logger from '../lib/logger';
 
@@ -78,6 +79,7 @@ const commands: CommandDefinition[] = [
     xbox,
     willithave,
     faq,
+    community,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};


### PR DESCRIPTION
Adds .community (also accepts .com) for support to explain how to find the correct community folder. 

Tested, results updated to latest commit:
![image](https://user-images.githubusercontent.com/87286435/135669527-a7eda141-3abd-40a9-a99d-4c9a2df57d54.png)

Discord: █▀█ █▄█ ▀█▀#2123