### PR TITLE
feat: added liveries command

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -41,6 +41,7 @@ import { roadmap } from './roadmap';
 import { clean } from './clean-install';
 import { CommandDefinition } from '../lib/command';
 import Logger from '../lib/logger';
+import { liveries } from './liveries';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -84,6 +85,7 @@ const commands: CommandDefinition[] = [
     community,
     roadmap,
     clean,
+    liveries,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};

--- a/src/commands/liveries.ts
+++ b/src/commands/liveries.ts
@@ -1,0 +1,13 @@
+import {CommandDefinition} from '../lib/command';
+import {CommandCategory} from '../constants';
+import { makeEmbed } from '../lib/embed';
+
+export const liveries: CommandDefinition = {
+    name: ['liveries', 'liv'],
+    description: 'Provides a link to the flightsim.to A32NX liveries page',
+    category: CommandCategory.FBW,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'A32NX Liveries',
+        description: 'Download liveries for the A32NX from [this link](https://flightsim.to/c/liveries/flybywire-a32nx/). Just unzip the .zip and place the contents of the file in your community folder.',
+    })),
+};


### PR DESCRIPTION
## Description

Added a liveries command that provides a link to the flightsim.to A32NX liveries page. Use .liveries or .liv to use the command.

## Test Results

<img width="868" alt="Screen Shot 2021-10-13 at 1 37 06 pm" src="https://user-images.githubusercontent.com/81839029/137057443-758fde8f-a469-4f34-b8bd-1de0c063b7c3.png">

## Discord Username

oim#0001

