### PR TITLE
feat: add .simversion command

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -40,6 +40,7 @@ import { community } from './community';
 import { roadmap } from './roadmap';
 import { clean } from './clean-install';
 import { liveries } from './liveries';
+import { simversion} from './simversion';
 import { CommandDefinition } from '../lib/command';
 import Logger from '../lib/logger';
 
@@ -86,6 +87,7 @@ const commands: CommandDefinition[] = [
     roadmap,
     clean,
     liveries,
+    simversion,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};

--- a/src/commands/simversion.ts
+++ b/src/commands/simversion.ts
@@ -1,0 +1,22 @@
+import { CommandDefinition } from '../lib/command';
+import { makeEmbed, makeLines } from '../lib/embed';
+import { CommandCategory } from '../constants';
+
+const SIMVERSION_HELP_URL = 'https://docs.flybywiresim.com/fbw-a32nx/assets/support-guide/MSFS-Version.jpg';
+
+export const simversion: CommandDefinition = {
+    name: ['simversion', 'msfsversion'],
+    description: 'Help to identify MSFS version for support',
+    category: CommandCategory.FBW,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'FlyByWire Support | Checking your MSFS version',
+        description: makeLines([
+            'In order to rule out version conflicts and continue with providing support for our aircraft, we need to see a screenshot showing your MSFS version. '
+          + 'The version of Microsoft Flight Simulator 2020 you\'re using can be found in several ways: ',
+            '',
+            'In the MSFS main menu you can click on your username in the upper right corner. This will display your version. '
+          + 'Further ways to identify and show your sim version can be found [here.](https://docs.flybywiresim.com/fbw-a32nx/support/#msfs-version)',
+        ]),
+        image: { url: SIMVERSION_HELP_URL },
+    })),
+};


### PR DESCRIPTION
Adds a command responding to .simversion and .msfsversion to request a screenshot showing the MSFS version for #support and show where to find that. Gives one method, and links to docs for further methods.

Tested, results:

![image](https://user-images.githubusercontent.com/87286435/137567142-43c7fa10-63d6-4c92-9156-397b38cf3b0f.png)

Discord:  █▀█ █▄█ ▀█▀#2123