### PR TITLE
feat: add .flightdeck command

### DIFF
--- a/src/commands/flightdeck.ts
+++ b/src/commands/flightdeck.ts
@@ -1,0 +1,13 @@
+import { CommandDefinition } from '../lib/command';
+import { CommandCategory } from '../constants';
+import { makeEmbed } from '../lib/embed';
+
+export const flightdeck: CommandDefinition = {
+    name: 'flightdeck',
+    description: 'Links to the clickable flight deck',
+    category: CommandCategory.FBW,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'FlyByWire A32NX | Interactive Flight Deck',
+        description: 'Please click [here](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/flight-deck/) for a clickable version of the A32NX flight deck, where you can click each panel to get further information on the panel.',
+    })),
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -40,6 +40,7 @@ import { community } from './community';
 import { roadmap } from './roadmap';
 import { clean } from './clean-install';
 import { liveries } from './liveries';
+import { flightdeck} from './flightdeck';
 import { CommandDefinition } from '../lib/command';
 import Logger from '../lib/logger';
 
@@ -86,6 +87,7 @@ const commands: CommandDefinition[] = [
     roadmap,
     clean,
     liveries,
+    flightdeck,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};


### PR DESCRIPTION
Provides a link to the interactive flight deck on docs for the A32NX found [here](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/flight-deck/).  Responds to .flightdeck. Expecting conflicts in index.ts when other open PR's are merged, will update accordingly as this happens.

Tested, results:

![image](https://user-images.githubusercontent.com/87286435/137567433-71295a2f-2def-4e7d-8fc3-cdc34a55dc5e.png)

Discord: █▀█ █▄█ ▀█▀#2123