### PR TITLE
feat: add .pfd command

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -40,6 +40,7 @@ import { community } from './community';
 import { roadmap } from './roadmap';
 import { clean } from './clean-install';
 import { liveries } from './liveries';
+import { pfd } from './pfd';
 import { CommandDefinition } from '../lib/command';
 import Logger from '../lib/logger';
 
@@ -86,6 +87,7 @@ const commands: CommandDefinition[] = [
     roadmap,
     clean,
     liveries,
+    pfd,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};

--- a/src/commands/pfd.ts
+++ b/src/commands/pfd.ts
@@ -1,0 +1,13 @@
+import { CommandDefinition } from '../lib/command';
+import { CommandCategory } from '../constants';
+import { makeEmbed } from '../lib/embed';
+
+export const pfd: CommandDefinition = {
+    name: ['pfd', 'pfdguide'],
+    description: 'Links to PFD guide in docs',
+    category: CommandCategory.FBW,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'FlyByWire A32NX | Primary Flight Display',
+        description: 'Please click [here](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/pfd/) for a clickable version of the A32NX Primary Flight Display (PFD), and in depth guide on the different sections of this display.',
+        })),
+};


### PR DESCRIPTION
Provides a link to the interactive PFD on docs for the A32NX found [here.](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/pfd/) Responds to .pfd and .pfdguide. Expecting conflicts in index.ts when other open PR's are merged, will update accordingly as this happens.

Tested, results: 
![image](https://user-images.githubusercontent.com/87286435/137567705-7c9e5dc7-51e4-4328-9c82-60a3ca1b2957.png)

Discord: █▀█ █▄█ ▀█▀#2123