### PR TITLE
fix: add .flightdeck and .pfd alias' to .briefing command

### DIFF
--- a/src/commands/briefing.ts
+++ b/src/commands/briefing.ts
@@ -3,7 +3,7 @@ import { CommandCategory } from '../constants';
 import { makeEmbed } from '../lib/embed';
 
 export const briefing: CommandDefinition = {
-    name: 'briefing',
+    name: ['briefing', 'flightdeck', 'pfd' ],
     description: 'Provides a link to the A320neo Pilot Briefing',
     category: CommandCategory.FBW,
     executor: (msg) => msg.channel.send(makeEmbed({


### PR DESCRIPTION
Updates .briefing to be called by .pfd and .flightdeck as well as the original .briefing for clearer use in server, when users are looking for the interactive flight deck and PFD these terms are often tried and failed.

Test results:
![image](https://user-images.githubusercontent.com/87286435/137599162-a2ee2b65-8db6-45e5-a792-a5ec76e243e2.png)

Discord: █▀█ █▄█ ▀█▀#2123

