### PR TITLE
feat: updated error command to provide error log instructions

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -17,7 +17,7 @@ import { membercount } from './utils/membercount';
 import { installer } from './general/installer';
 import { roleinfo } from './utils/roleinfo';
 import { adirs } from './a32nx/adirs';
-import { installererror } from './support/installererror';
+import { logs } from './support/logs';
 import { reportedissues } from './support/reportedissues';
 import { autopilot } from './a32nx/autopilot';
 import { checklist } from './a32nx/checklist';
@@ -70,7 +70,7 @@ const commands: CommandDefinition[] = [
     installer,
     roleinfo,
     adirs,
-    installererror,
+    logs,
     reportedissues,
     autopilot,
     checklist,

--- a/src/commands/support/logs.ts
+++ b/src/commands/support/logs.ts
@@ -9,7 +9,7 @@ export const logs: CommandDefinition = {
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'FlyByWire A32NX | Installer Logs',
         description: makeLines([
-            'If you encounter an error with the installer, please send us a copy of the logs. To do this:',
+            'If you encounter an error with the installer, please send a copy of the installer log here in <#785976111875751956>. To do this:',
             '1. Open the debug tool with ^Ctrl + F12',
             '2. Find and select \'Console\' in the top menu',
             '3. Right click anywhere in the log displayed',

--- a/src/commands/support/logs.ts
+++ b/src/commands/support/logs.ts
@@ -5,7 +5,7 @@ import { makeEmbed, makeLines } from '../../lib/embed';
 export const logs: CommandDefinition = {
     name: ['installerlogs', 'logs'],
     description: 'Provides an explanation on how to receive installer error logs for support',
-    category: CommandCategory.FBW,
+    category: CommandCategory.SUPPORT,
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'FlyByWire Support | Installer Logs',
         description: makeLines([

--- a/src/commands/support/logs.ts
+++ b/src/commands/support/logs.ts
@@ -1,0 +1,19 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed, makeLines } from '../../lib/embed';
+
+export const logs: CommandDefinition = {
+    name: ['installerlogs', 'logs'],
+    description: 'Provides an explanation on how to receive installer error logs for support',
+    category: CommandCategory.FBW,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'FlyByWire A32NX | Installer Logs',
+        description: makeLines([
+            'If you encounter an error with the installer, please send us a copy of the logs. To do this:',
+            '1. Open the debug tool with ^Ctrl + F12',
+            '2. Find and select \'Console\' in the top menu',
+            '3. Right click anywhere in the log displayed',
+            '4. Click \'Save as\' and send the log to us',
+        ]),
+    })),
+};

--- a/src/commands/support/logs.ts
+++ b/src/commands/support/logs.ts
@@ -7,7 +7,7 @@ export const logs: CommandDefinition = {
     description: 'Provides an explanation on how to receive installer error logs for support',
     category: CommandCategory.FBW,
     executor: (msg) => msg.channel.send(makeEmbed({
-        title: 'FlyByWire A32NX | Installer Logs',
+        title: 'FlyByWire Support | Installer Logs',
         description: makeLines([
             'If you encounter an error with the installer, please send a copy of the installer log here in <#785976111875751956>. To do this:',
             '1. Open the debug tool with ^Ctrl + F12',

--- a/src/commands/support/logs.ts
+++ b/src/commands/support/logs.ts
@@ -9,7 +9,8 @@ export const logs: CommandDefinition = {
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'FlyByWire Support | Installer Logs',
         description: makeLines([
-            'If you encounter an error with the installer, please send a copy of the installer log here in <#785976111875751956>. To do this:',
+            'If you encounter an error with the installer, please send a copy of the installer log here in <#785976111875751956> To do this:',
+            ,
             '1. Open the debug tool with ^Ctrl + F12',
             '2. Find and select \'Console\' in the top menu',
             '3. Right click anywhere in the log displayed',


### PR DESCRIPTION
## Description

As requested by @Valastiri, the .installererror command has been updated to provide instructions on how to send installer error logs. The command has been renamed to .installerlogs and .logs . The #deleted-channel in the screenshot is due to the channel id being the actual FBW support channel. 

## Test Results

![logs2](https://user-images.githubusercontent.com/81839029/139105321-0f975b66-f4f7-4fbf-8c96-d6a6c1366f13.png)

## Discord Username

oim#0001
