### PR TITLE
fix: proper units for different airports for metar command

### DIFF
--- a/src/commands/utils/metar.ts
+++ b/src/commands/utils/metar.ts
@@ -35,7 +35,7 @@ export const metar: CommandDefinition = {
                     `**Visibility:** ${metarReport.visibility.repr}${metarReport.units.visibility}`,
                     `**Temperature:** ${metarReport.temperature.repr}C`,
                     `**Dew Point:** ${metarReport.dewpoint.repr}C`,
-                    `**Altimeter:** ${metarReport.altimeter.repr} (${metarReport.units.altimeter})`,
+                    `**Altimeter:** ${metarReport.altimeter.value.toString()} ${metarReport.units.altimeter}`,
                 ]),
                 fields: [
                     { name: 'Unsure of how to read the raw report?', value: 'Please refer to our guide [here.](https://docs.flybywiresim.com/pilots-corner/airliner-flying-guide/weather/)', inline: false },


### PR DESCRIPTION
## Description

Previously all airports would say meters for visibility which would be incorrect if the airport published visibility in statute miles. This fixes it so that it will give the correct units. 

## Test Results

![metar6](https://user-images.githubusercontent.com/81839029/139227101-5bdd5e38-2c5d-446a-8034-f8f45b53fa56.png)

## Discord Username

oim#0001