### PR TITLE
feat: added new ctrl e alias

### DIFF
--- a/src/commands/a32nx/ctrl_e.ts
+++ b/src/commands/a32nx/ctrl_e.ts
@@ -3,7 +3,7 @@ import { makeEmbed, makeLines } from '../../lib/embed';
 import { CommandCategory } from '../../constants';
 
 export const ctrl_e: CommandDefinition = {
-    name: ['ctrle', 'ctrl+e', 'enginestart'],
+    name: ['ctrle', 'ctrl+e', 'ctrl-e', 'enginestart'],
     description: 'Displays help regarding CTRL+E engine start',
     category: CommandCategory.A32NX,
     executor: (msg) => msg.channel.send(makeEmbed({


### PR DESCRIPTION
## Description

As requested by Cdr_Maverick, I have added ctrl-e as an alias for the ctrle command. 

## Test Results

![ctrle](https://user-images.githubusercontent.com/81839029/139587384-78f281be-0f10-413b-8a5b-74cff7d6cc8d.png)

## Discord Username

oim#0001
