### PR TITLE
feat: decide between DM or docs when using help command

### DIFF
--- a/src/commands/utils/help.ts
+++ b/src/commands/utils/help.ts
@@ -17,7 +17,7 @@ export const help: CommandDefinition = {
             description: makeLines([
                 'Would you like to:',
                 '1. Receive a list of the available commands as a DM',
-                '2. Receive a link to our docs site with changelogs',
+                '2. Receive a link with a list of the available commands/changelog on our docs site ',
             ]),
         });
 

--- a/src/commands/utils/help.ts
+++ b/src/commands/utils/help.ts
@@ -16,7 +16,7 @@ export const help: CommandDefinition = {
             title: 'FlyByWire Simulations | Help',
             description: makeLines([
                 'Would you like to:',
-                '1. Receive a help DM',
+                '1. Receive a list of the available commands as a DM',
                 '2. Receive a link to our docs site with changelogs',
             ]),
         });

--- a/src/commands/utils/help.ts
+++ b/src/commands/utils/help.ts
@@ -1,6 +1,6 @@
 import { DMChannel, EmbedFieldData, User } from 'discord.js';
 import { CommandDefinition } from '../../lib/command';
-import { makeEmbed } from '../../lib/embed';
+import { makeEmbed, makeLines } from '../../lib/embed';
 import commands from '../index';
 import { CommandCategory } from '../../constants';
 import Logger from '../../lib/logger';
@@ -9,22 +9,81 @@ export const help: CommandDefinition = {
     name: 'help',
     description: 'Sends a list of available commands to the user',
     category: CommandCategory.UTILS,
-    executor: (msg) => msg.author.createDM()
-        .then(async (dmChannel) => {
+    executor: async (msg) => {
+        const { author } = msg;
+
+        const embed = makeEmbed({
+            title: 'FlyByWire Simulations | Help',
+            description: makeLines([
+                'Would you like to:',
+                '1. Receive a help DM',
+                '2. Receive a link to our docs site with changelogs',
+            ]),
+        });
+
+        // Decide between DM or docs link
+        const selectorMsg = await msg.reply(embed);
+
+        try {
             await msg.delete();
+        } catch (e) {
+            Logger.debug('Message was already deleted');
+        }
 
-            const response = await msg.reply('I\'ve DM\'d you with the list of the commands you can use!');
-            setTimeout(() => {
-                response.delete();
-            }, 4_000);
+        const reactionFilter = (reaction, user) => ['1️⃣', '2️⃣'].includes(reaction.emoji.name) && user.id === author.id;
+        selectorMsg.awaitReactions(reactionFilter, {
+            max: 1,
+            time: 60000,
+            errors: ['time'],
+        })
+            .then(async (collected) => {
+                const reaction = collected.first();
 
-            // Catch all errors to prevent leaking DM activity to public error embeds
-            try {
-                await handleDmCommunication(dmChannel, msg.author);
-            } catch (e) {
-                Logger.error(e);
-            }
-        }),
+                switch (reaction.emoji.name) {
+                case '1️⃣':
+                    // Slide into the DMs
+                    author.createDM()
+                        .then(async (dmChannel) => {
+                            const response = await selectorMsg.reply('I\'ve DM\'d you with the list of the commands you can use!');
+                            await selectorMsg.delete();
+
+                            setTimeout(() => {
+                                response.delete();
+                            }, 4_000);
+
+                            // Catch all errors to prevent leaking DM activity to public error embeds
+                            try {
+                                await handleDmCommunication(dmChannel, author);
+                            } catch (e) {
+                                Logger.error(e);
+                            }
+                        });
+
+                    break;
+                case '2️⃣':
+                    const embed = makeEmbed({
+                        title: 'FlyByWire Simulations | Documentation',
+                        description: 'https://docs.flybywiresim.com/',
+                    });
+
+                    await selectorMsg.reply(embed);
+
+                    // Delete the selector
+                    await selectorMsg.delete();
+                    break;
+                default:
+                    // Unknown reaction -> ignore
+                    break;
+                }
+            })
+            .catch(async () => {
+                await selectorMsg.delete();
+            });
+
+        // Send reactions after listener has been set up
+        await selectorMsg.react('1️⃣');
+        await selectorMsg.react('2️⃣');
+    },
 };
 
 async function handleDmCommunication(dmChannel: DMChannel, author: User, index: number = 0) {

--- a/src/commands/utils/help.ts
+++ b/src/commands/utils/help.ts
@@ -63,7 +63,7 @@ export const help: CommandDefinition = {
                 case '2️⃣':
                     const embed = makeEmbed({
                         title: 'FlyByWire Simulations | Documentation',
-                        description: 'https://docs.flybywiresim.com/',
+                        description: 'https://docs.flybywiresim.com/dev-corner/development-projects/discord-bot/',
                     });
 
                     await selectorMsg.reply(embed);


### PR DESCRIPTION
feat: decide between DM or docs when using help command

## Description
Presents an emote selector when using the `.help` command

## Test Results
`.help`

![image](https://user-images.githubusercontent.com/1652722/139953711-f95db5b7-066c-4b2a-a95c-8fc9107170a1.png)
`Select 2`

![image](https://user-images.githubusercontent.com/1652722/139953754-f0261586-3961-46c5-8a0f-a2565b73aef1.png)


## Discord Username
nistei#1362
