### PR TITLE
feat: added avatar command

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -51,6 +51,7 @@ import { metar } from './utils/metar';
 import { qa } from './general/qa';
 import { ptu } from './funnies/ptu';
 import { cursor } from './support/cursor';
+import { avatar } from './utils/avatar';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -104,6 +105,7 @@ const commands: CommandDefinition[] = [
     qa,
     ptu,
     cursor,
+    avatar,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};

--- a/src/commands/utils/avatar.ts
+++ b/src/commands/utils/avatar.ts
@@ -10,7 +10,7 @@ export const avatar: CommandDefinition = {
         const user = msg.mentions.users.first() || msg.author;
         user.displayAvatarURL({ dynamic: true })
         return msg.channel.send(makeEmbed({
-            title: `${user.username}'s Avatar`,
+            title: `${user.tag}'s Avatar`,
             image: { url: user.displayAvatarURL({ dynamic: true }) },
         }));
     },

--- a/src/commands/utils/avatar.ts
+++ b/src/commands/utils/avatar.ts
@@ -11,7 +11,7 @@ export const avatar: CommandDefinition = {
         user.displayAvatarURL({ dynamic: true })
         return msg.channel.send(makeEmbed({
             title: `${user.tag}'s Avatar`,
-            image: { url: user.displayAvatarURL({ dynamic: true }) },
+            image: { url: user.displayAvatarURL({ dynamic: true, size: 4096 }) },
         }));
     },
 };

--- a/src/commands/utils/avatar.ts
+++ b/src/commands/utils/avatar.ts
@@ -1,0 +1,18 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed } from '../../lib/embed';
+
+export const avatar: CommandDefinition = {
+    name: ['avatar', 'av'],
+    description: 'Shows the selected user\'s avatar',
+    category: CommandCategory.UTILS,
+    executor: (msg) => {
+        const user = msg.mentions.users.first() || msg.author;
+        user.displayAvatarURL({ dynamic: true })
+        return msg.channel.send(makeEmbed({
+            title: `${user.username}'s Avatar`,
+            image: { url: user.displayAvatarURL({ dynamic: true }) },
+        }));
+    },
+};
+


### PR DESCRIPTION
## Description

Commonly used dyno feature. Sends an embed of the requested user's profile picture. Commands are:
.avatar <user>
.av <user>

If a user is not specified, the message author's profile picture will be displayed. 

## Test Results

![avatarcommand3](https://user-images.githubusercontent.com/81839029/140062264-461b87a3-f661-4031-ba58-892f837694cf.png)

## Discord Username

oim#0001
