### PR TITLE
fix: remove CTD disclaimer in .printer

### DIFF
--- a/src/commands/a32nx/printer.ts
+++ b/src/commands/a32nx/printer.ts
@@ -9,7 +9,6 @@ export const printer: CommandDefinition = {
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'FlyByWire A32NX | How do I use the printer?',
         description: 'Please watch our video tutorial on how to use the FlyByWire A32NX printer [here.](https://www.youtube.com/watch?v=i3ughyFtnCM)',
-        footer: { text: 'Warning: Using the printer may cause a crash to desktop. This issue occurs randomly and we are currently looking for ways to reproduce and resolve it.'}
     })),
 };
 


### PR DESCRIPTION
## Description

https://github.com/flybywiresim/a32nx/pull/6088

This pull request may fix the printer CTD. If the QA team has found that it does fix it, this PR should be merged. It removes the disclaimer that the printer may cause CTDs. 

## Test Results

![printer2](https://user-images.githubusercontent.com/81839029/141021161-109125d1-3c39-4fc7-86c0-52059df9c4fa.png)

## Discord Username

oim#0001
