### PR TITLE
feat: added freetext command

### DIFF
--- a/src/commands/a32nx/freetext.ts
+++ b/src/commands/a32nx/freetext.ts
@@ -4,7 +4,7 @@ import { makeEmbed } from '../../lib/embed';
 
 export const freetext: CommandDefinition = {
     name: ['freetext', 'ft'],
-    description: 'Provides a link to the FlyByWire free text tutorial video',
+    description: 'Provides a link to the FlyByWire free text feature guide',
     category: CommandCategory.A32NX,
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'FlyByWire A32NX | Free Text',

--- a/src/commands/a32nx/freetext.ts
+++ b/src/commands/a32nx/freetext.ts
@@ -8,6 +8,6 @@ export const freetext: CommandDefinition = {
     category: CommandCategory.A32NX,
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'FlyByWire A32NX | Free Text',
-        description: 'Please see our [guide](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/freetext) on how to use the FlyByWire A32NX Free Text feature.',
+        description: 'Please see our [guide](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/freetext/) on how to use the FlyByWire A32NX Free Text feature.',
     })),
 };

--- a/src/commands/a32nx/freetext.ts
+++ b/src/commands/a32nx/freetext.ts
@@ -1,0 +1,13 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed } from '../../lib/embed';
+
+export const freetext: CommandDefinition = {
+    name: ['freetext', 'ft'],
+    description: 'Provides a link to the FlyByWire free text tutorial video',
+    category: CommandCategory.A32NX,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'FlyByWire A32NX | Free Text',
+        description: 'Please see our [guide](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/freetext) on how to use the FlyByWire A32NX Free Text feature.',
+    })),
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -64,6 +64,7 @@ import { pov } from './funnies/pov';
 import { shame } from './funnies/shame';
 import { xp } from './funnies/xp';
 import { whened } from './funnies/whened';
+import { freetext } from './a32nx/freetext';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -130,6 +131,7 @@ const commands: CommandDefinition[] = [
     shame,
     xp,
     whened,
+    freetext,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};


### PR DESCRIPTION
## Description

Provides a link to instructions on how to use the freetext feature in the A32NX. Aliases are .freetext and .ft . 

## Test Results

![freetext](https://user-images.githubusercontent.com/81839029/141128852-d3c44081-2ea5-46d9-8878-ed5eb5d8b166.png)

## Discord Username

oim#0001
