### PR TITLE
refactor: minor improvements to .exp, .versions, .tug and move .cowsay

### DIFF
--- a/src/commands/a32nx/experimental.ts
+++ b/src/commands/a32nx/experimental.ts
@@ -8,8 +8,8 @@ export const experimental: CommandDefinition = {
     category: CommandCategory.A32NX,
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'FlyByWire A32NX | Experimental Version',
-        description: 'Our custom FMS has now been moved into the development branch and Experimental is now temporarily on hold. Please switch to our development branch to continue using this feature with the latest updates. '
-                + 'Our [Experimental Version Support Page](https://docs.flybywiresim.com/fbw-a32nx/support/exp/) will be updated when start work on new features in the experimental branch. '
+        description: 'Our custom FMS has been moved into the development branch and Experimental is now temporarily on hold. Please switch to our development branch to continue using this feature with the latest updates. '
+                + 'Our [Experimental Version Support Page](https://docs.flybywiresim.com/fbw-a32nx/support/exp/) will be updated when we start working on new features in the experimental branch. '
                 + 'No support will be offered via Discord for Experimental. ',
     })),
 };

--- a/src/commands/a32nx/versions.ts
+++ b/src/commands/a32nx/versions.ts
@@ -33,8 +33,8 @@ export const versions: CommandDefinition = {
             },
             {
                 name: 'Experimental',
-                value: '> Our custom FMS has now been moved into the development branch and Experimental is now temporarily on hold. Please switch to our development branch to continue using this feature with the latest updates. '
-                        + 'Our [Experimental Version Support Page](https://docs.flybywiresim.com/fbw-a32nx/support/exp/) will be updated when start work on new features in the experimental branch. No support will be offered via Discord. ',
+                value: '> Our custom FMS has been moved into the development branch and Experimental is now temporarily on hold. Please switch to our development branch to continue using this feature with the latest updates. '
+                        + 'Our [Experimental Version Support Page](https://docs.flybywiresim.com/fbw-a32nx/support/exp/) will be updated when we start working on new features in the experimental branch. No support will be offered via Discord. ',
                 inline: false,
             },
         ],

--- a/src/commands/funnies/cowsay.ts
+++ b/src/commands/funnies/cowsay.ts
@@ -5,7 +5,7 @@ import { CommandCategory } from '../../constants';
 export const cowsay: CommandDefinition = {
     name: ['cowsay', 'cs'],
     description: 'Emulates the famous UNIX program `cowsay`.',
-    category: CommandCategory.UTILS,
+    category: CommandCategory.FUNNIES,
     executor: (msg) => {
         const text = msg.content.replace(/\.(cowsay|cs)\s*/, '');
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -67,7 +67,7 @@ import { whened } from './funnies/whened';
 import { station } from './utils/station';
 import { addon } from './funnies/addon';
 import { freetext } from './a32nx/freetext';
-import { cowsay } from './utils/cowsay';
+import { cowsay } from './funnies/cowsay';
 import { synaptic } from './general/synaptic';
 import { directx12 } from './support/directx12';
 import { cfms } from './a32nx/cfms';

--- a/src/commands/support/tug.ts
+++ b/src/commands/support/tug.ts
@@ -10,7 +10,9 @@ export const tug: CommandDefinition = {
         title: 'FlyByWire Support | My Aircraft is Stuck!',
         description: makeLines([
             'Make sure you do not have the "NW STRG DISC" message on the upper ECAM display. ',
+            '',
             'If you do, please press "Shift" + "P" on your keyboard to disconnect the invisible pushback tug.',
+            '',
             'Please read our guide [here](https://docs.flybywiresim.com/fbw-a32nx/support/reported-issues/#nose-wheel-steering-locked-nw-strg-disc) for more information. ',
         ]), 
     })),


### PR DESCRIPTION
This PR applies minor typo corrections to .exp and .versions that slipped through the initial update and copychecks. 
Also applies line breaks to .tug and moves .cowsay into the funnies command category.

Test results: 
![image](https://user-images.githubusercontent.com/87286435/143252584-c84582ae-f84e-4b7e-b976-b47214bbf3b6.png)
![image](https://user-images.githubusercontent.com/87286435/143309284-70905f5c-3091-49df-9958-9fe0211c4d46.png)
![image](https://user-images.githubusercontent.com/87286435/143309296-d24664da-b6f9-4edf-b9f9-dd76d26d4a1c.png)


Discord: █▀█ █▄█ ▀█▀#2123