### PR TITLE
fix: add mod team role ID to .faq

### DIFF
--- a/src/commands/moderation/faq.ts
+++ b/src/commands/moderation/faq.ts
@@ -46,7 +46,7 @@ const embeds = [
             },
             {
                 name: `I am a real life Aero Engineer, GA, A320 or A380 Pilot, or Cabin Crew. Where do I get my role?`,
-                value: "> You simply DM <@540637101302087703> or <@206276286782504960> with proof of your job!\n ",
+                value: "> You simply DM one of the <@&739187150909866137> with proof of your job!\n ",
             },
 
         ],


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description
Changes the FAQ section to advise users to message mod team rather than just two users for pilot verification
<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results
![image](https://user-images.githubusercontent.com/87286435/145615641-e062816a-37f9-4228-8ea5-8962aad651ed.png)
Will show moderation team role when merged, checked with a role ID from test server and works all fine!
<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username
█▀█ █▄█ ▀█▀#2123
<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
