### PR TITLE
feat: added goldenrules command

### DIFF
--- a/src/commands/general/goldenrules.ts
+++ b/src/commands/general/goldenrules.ts
@@ -1,0 +1,13 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed } from '../../lib/embed';
+
+export const goldenrules: CommandDefinition = {
+    name: ['goldenrules', 'golden', 'gr'],
+    description: 'Provides an image describing the golden rules an Airbus pilot should follow',
+    category: CommandCategory.GENERAL,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'FlyByWire | Golden Rules',
+        image: { url: 'https://media.discordapp.net/attachments/898602626436964402/921043008923795466/55982629-DD45-4E98-97E6-2B61479D5401.png?width=554&height=676' },
+    })),
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -81,6 +81,7 @@ import { rules } from './moderation/rules';
 import { fixinfo } from './a32nx/fixinfo';
 import { welcome } from './moderation/welcome';
 import { sop } from './a32nx/sop';
+import { goldenrules } from './general/goldenrules';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -164,6 +165,7 @@ const commands: CommandDefinition[] = [
     fixinfo,
     welcome,
     sop,
+    goldenrules,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};


### PR DESCRIPTION
## Description

As requested by Cdr_Maverick, I have added the golden rules command. It provides an image of the golden rules an Airbus pilot should follow. Aliases are .golden, .goldenrules and .gr

## Test Results

![image](https://user-images.githubusercontent.com/81839029/146389041-e02404c8-0680-48f6-86d9-fae315a9eefe.png)

## Discord Username

oim#0001