### PR TITLE
fix: fixed fridge image

### DIFF
--- a/src/commands/funnies/fridge.ts
+++ b/src/commands/funnies/fridge.ts
@@ -2,7 +2,7 @@ import { CommandDefinition } from '../../lib/command';
 import { makeEmbed } from '../../lib/embed';
 import { CommandCategory } from '../../constants';
 
-const FRIDGE_URL = 'https://media.discordapp.net/attachments/898602626436964402/921199183430549524/samsung-family-hub-refrigerator-1_1024x1024.png';
+const FRIDGE_URL = 'https://media.discordapp.net/attachments/898602626436964402/921205269927706675/samsung-family-hub-refrigerator-1_1024x1024clean.png';
 
 export const fridge: CommandDefinition = {
     name: 'fridge',


### PR DESCRIPTION
## Description

changed the .fridge image to another cleaner version of that image.

## Test Results

![image](https://user-images.githubusercontent.com/81839029/146471727-022025bd-a569-4d8b-9ecf-2c516b1a0fd6.png)

## Discord Username

oim#0001
