### PR TITLE
fix: .welcome emotes and .faq docs link

### DIFF
--- a/src/commands/moderation/faq.ts
+++ b/src/commands/moderation/faq.ts
@@ -56,7 +56,7 @@ const embeds = [
         fields: [
             {
                 name: `Docs FAQ`,
-                value: "> https://docs.flybywiresim.com/fbw-a32nx/support/faq/\n ",
+                value: "> https://docs.flybywiresim.com/fbw-a32nx/faq/\n ",
             },
             {
                 name: `Beginner Guide`,

--- a/src/commands/moderation/welcome.ts
+++ b/src/commands/moderation/welcome.ts
@@ -12,7 +12,7 @@ const SOCIAL_EMBED = [
     makeEmbed({
         title: '<:Partnered:921520970123059231> FlyByWireSimulations | Socials',
         description: makeLines([
-            '<:FBW:921524619406635050> <https://www.flybywiresim.com>',
+            '<:FBW:921521552699310141> <https://www.flybywiresim.com>',
             '<:Twitter:921524619406635050> <https://twitter.com/FlyByWireSim>',
             '<:Facebook:921524619406635050> <https://www.facebook.com/FlyByWireSimulations>',
             '<:Youtube:921524619406635050> <https://www.youtube.com/c/FlyByWireSimulations>',

--- a/src/commands/moderation/welcome.ts
+++ b/src/commands/moderation/welcome.ts
@@ -14,7 +14,7 @@ const SOCIAL_EMBED = [
         description: makeLines([
             '<:FBW:921521552699310141> <https://www.flybywiresim.com>',
             '<:Twitter:921521552942571601> <https://twitter.com/FlyByWireSim>',
-            '<:Facebook:921524619406635050> <https://www.facebook.com/FlyByWireSimulations>',
+            '<:Facebook:921521552984539146> <https://www.facebook.com/FlyByWireSimulations>',
             '<:Youtube:921524619406635050> <https://www.youtube.com/c/FlyByWireSimulations>',
             '<:Twitch:921524619406635050> <https://www.twitch.tv/flybywiresimulations>',
         ])

--- a/src/commands/moderation/welcome.ts
+++ b/src/commands/moderation/welcome.ts
@@ -10,7 +10,7 @@ const IMPORTANT_INFO_IMAGE_URL = 'https://cdn.discordapp.com/attachments/8256744
 
 const SOCIAL_EMBED = [
     makeEmbed({
-        title: '<:Partnered:921524619406635050> FlyByWireSimulations | Socials',
+        title: '<:Partnered:921520970123059231> FlyByWireSimulations | Socials',
         description: makeLines([
             '<:FBW:921524619406635050> <https://www.flybywiresim.com>',
             '<:Twitter:921524619406635050> <https://twitter.com/FlyByWireSim>',

--- a/src/commands/moderation/welcome.ts
+++ b/src/commands/moderation/welcome.ts
@@ -23,7 +23,7 @@ const SOCIAL_EMBED = [
 
 const SUPPORT_EMBED = [
     makeEmbed({
-        title: '<:Partnered:921524619406635050> FlyByWireSimulations | Support Us',
+        title: '<:Partnered:921520970123059231> FlyByWireSimulations | Support Us',
         description: makeLines([
             'You are able to voluntarily support us financially to ensure we are able to cover the costs of servers and developmental resources.',
             '',

--- a/src/commands/moderation/welcome.ts
+++ b/src/commands/moderation/welcome.ts
@@ -10,20 +10,20 @@ const IMPORTANT_INFO_IMAGE_URL = 'https://cdn.discordapp.com/attachments/8256744
 
 const SOCIAL_EMBED = [
     makeEmbed({
-        title: '<:Partnered:799926764407226410> FlyByWireSimulations | Socials',
+        title: '<:Partnered:921524619406635050> FlyByWireSimulations | Socials',
         description: makeLines([
-            '<:FBW:909557440482250782> <https://www.flybywiresim.com>',
-            '<:Twitter:909556629341634580> <https://twitter.com/FlyByWireSim>',
-            '<:Facebook:909556629291303022> <https://www.facebook.com/FlyByWireSimulations>',
-            '<:Youtube:909556629396156416> <https://www.youtube.com/c/FlyByWireSimulations>',
-            '<:Twitch:909556629270315088> <https://www.twitch.tv/flybywiresimulations>',
+            '<:FBW:921524619406635050> <https://www.flybywiresim.com>',
+            '<:Twitter:921524619406635050> <https://twitter.com/FlyByWireSim>',
+            '<:Facebook:921524619406635050> <https://www.facebook.com/FlyByWireSimulations>',
+            '<:Youtube:921524619406635050> <https://www.youtube.com/c/FlyByWireSimulations>',
+            '<:Twitch:921524619406635050> <https://www.twitch.tv/flybywiresimulations>',
         ])
     })
 ]
 
 const SUPPORT_EMBED = [
     makeEmbed({
-        title: '<:Partnered:799926764407226410> FlyByWireSimulations | Support Us',
+        title: '<:Partnered:921524619406635050> FlyByWireSimulations | Support Us',
         description: makeLines([
             'You are able to voluntarily support us financially to ensure we are able to cover the costs of servers and developmental resources.',
             '',
@@ -34,7 +34,7 @@ const SUPPORT_EMBED = [
 
 const IMPORTANT_INFO_EMBED = [
     makeEmbed({
-        title: '<:Partnered:799926764407226410> FlyByWireSimulations | Important Info',
+        title: '<:Partnered:921524619406635050> FlyByWireSimulations | Important Info',
         description: 'By being a member of our Discord Server, you agree to the following, and failure to do so can result in removal from the server.',
         fields: [
             {
@@ -51,7 +51,7 @@ const IMPORTANT_INFO_EMBED = [
 
 const HELP_EMBED = [
     makeEmbed({
-        title: '<:Partnered:799926764407226410> FlyByWireSimulations | Help and Support',
+        title: '<:Partnered:921524619406635050> FlyByWireSimulations | Help and Support',
         fields: [
             {
                 name: `Documentation`,

--- a/src/commands/moderation/welcome.ts
+++ b/src/commands/moderation/welcome.ts
@@ -13,7 +13,7 @@ const SOCIAL_EMBED = [
         title: '<:Partnered:921520970123059231> FlyByWireSimulations | Socials',
         description: makeLines([
             '<:FBW:921521552699310141> <https://www.flybywiresim.com>',
-            '<:Twitter:921524619406635050> <https://twitter.com/FlyByWireSim>',
+            '<:Twitter:921521552942571601> <https://twitter.com/FlyByWireSim>',
             '<:Facebook:921524619406635050> <https://www.facebook.com/FlyByWireSimulations>',
             '<:Youtube:921524619406635050> <https://www.youtube.com/c/FlyByWireSimulations>',
             '<:Twitch:921524619406635050> <https://www.twitch.tv/flybywiresimulations>',

--- a/src/commands/moderation/welcome.ts
+++ b/src/commands/moderation/welcome.ts
@@ -34,7 +34,7 @@ const SUPPORT_EMBED = [
 
 const IMPORTANT_INFO_EMBED = [
     makeEmbed({
-        title: '<:Partnered:921524619406635050> FlyByWireSimulations | Important Info',
+        title: '<:Partnered:921520970123059231> FlyByWireSimulations | Important Info',
         description: 'By being a member of our Discord Server, you agree to the following, and failure to do so can result in removal from the server.',
         fields: [
             {

--- a/src/commands/moderation/welcome.ts
+++ b/src/commands/moderation/welcome.ts
@@ -16,7 +16,7 @@ const SOCIAL_EMBED = [
             '<:Twitter:921521552942571601> <https://twitter.com/FlyByWireSim>',
             '<:Facebook:921521552984539146> <https://www.facebook.com/FlyByWireSimulations>',
             '<:Youtube:921521552829329488> <https://www.youtube.com/c/FlyByWireSimulations>',
-            '<:Twitch:921524619406635050> <https://www.twitch.tv/flybywiresimulations>',
+            '<:Twitch:921521552623804506> <https://www.twitch.tv/flybywiresimulations>',
         ])
     })
 ]

--- a/src/commands/moderation/welcome.ts
+++ b/src/commands/moderation/welcome.ts
@@ -15,7 +15,7 @@ const SOCIAL_EMBED = [
             '<:FBW:921521552699310141> <https://www.flybywiresim.com>',
             '<:Twitter:921521552942571601> <https://twitter.com/FlyByWireSim>',
             '<:Facebook:921521552984539146> <https://www.facebook.com/FlyByWireSimulations>',
-            '<:Youtube:921524619406635050> <https://www.youtube.com/c/FlyByWireSimulations>',
+            '<:Youtube:921521552829329488> <https://www.youtube.com/c/FlyByWireSimulations>',
             '<:Twitch:921524619406635050> <https://www.twitch.tv/flybywiresimulations>',
         ])
     })

--- a/src/commands/moderation/welcome.ts
+++ b/src/commands/moderation/welcome.ts
@@ -51,7 +51,7 @@ const IMPORTANT_INFO_EMBED = [
 
 const HELP_EMBED = [
     makeEmbed({
-        title: '<:Partnered:921524619406635050> FlyByWireSimulations | Help and Support',
+        title: '<:Partnered:921520970123059231> FlyByWireSimulations | Help and Support',
         fields: [
             {
                 name: `Documentation`,


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:



- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description
Replaces emote ID's in .welcome for use in prod bot with new emojis.
Also corrects a 404'd link to docs FAQ as raised on discord. Redirects to https://docs.flybywiresim.com/fbw-a32nx/faq/

<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results

Tested, link works on .faq update, as for .welcome won't show properly until merged into prod as the emotes have different ID's. 

![image](https://user-images.githubusercontent.com/87286435/146646893-a41d29e5-38c9-458f-a213-13ca9478301b.png)
![image](https://user-images.githubusercontent.com/87286435/146646900-3d79a460-19bf-4632-b48d-703cd9229131.png)

<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username
█▀█ █▄█ ▀█▀#2123
<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
