### PR TITLE
feat: added assistance command

### DIFF
--- a/src/commands/a32nx/assistance.ts
+++ b/src/commands/a32nx/assistance.ts
@@ -1,0 +1,18 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed, makeLines } from '../../lib/embed';
+
+export const assistance: CommandDefinition = {
+    name: ['assistance', 'assi', 'as'],
+    description: 'Explains to the user why assistance options should be disabled',
+    category: CommandCategory.A32NX,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'FlyByWire A32NX | Assistance Options',
+        description: makeLines([
+            'The A32NX is not compatible with the Microsoft Flight Simulator assistance feature "Auto-Rudder".** It is required to deactivate this feature in MSFS.**',
+            '',
+            'We recommend to turn off all assistance features in MSFS as they interfere with the A32NX systems.'
+        ]),
+        image: { url: 'https://docs.flybywiresim.com/fbw-a32nx/assets/nw-tiller/assistance-options.png' },
+    })),
+};

--- a/src/commands/a32nx/assistance.ts
+++ b/src/commands/a32nx/assistance.ts
@@ -11,7 +11,7 @@ export const assistance: CommandDefinition = {
         description: makeLines([
             'The A32NX is not compatible with the Microsoft Flight Simulator assistance feature "Auto-Rudder".** It is required to deactivate this feature in MSFS.**',
             '',
-            'We recommend to turn off all assistance features in MSFS as they interfere with the A32NX systems.'
+            'We recommend turning off all assistance features in MSFS as they interfere with the A32NX systems.'
         ]),
         image: { url: 'https://docs.flybywiresim.com/fbw-a32nx/assets/nw-tiller/assistance-options.png' },
     })),

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -84,6 +84,7 @@ import { sop } from './a32nx/sop';
 import { goldenrules } from './general/goldenrules';
 import { fridge } from './funnies/fridge';
 import { tiller } from './a32nx/tiller';
+import { assistance } from './a32nx/assistance';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -170,6 +171,7 @@ const commands: CommandDefinition[] = [
     goldenrules,
     fridge,
     tiller,
+    assistance,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};


### PR DESCRIPTION
## Description

As requested by mav, the assistance command explains to the user why all assistance options should be disabled. Aliases are:

.assistance
.assi
.as

## Test Results

![image](https://user-images.githubusercontent.com/81839029/146679004-2c3da351-6af5-4482-8ba5-2d651f98aa70.png)

## Discord Username

oim#0001