### PR TITLE
add remote mcdu command

### DIFF
--- a/src/commands/a32nx/mcdu.ts
+++ b/src/commands/a32nx/mcdu.ts
@@ -1,0 +1,13 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed } from '../../lib/embed';
+
+export const mcdu: CommandDefinition = {
+    name: ['remotemcdu', 'mcdu', 'remote'],
+    description: 'Provides a link to the FlyByWire remote MCDU feature guide',
+    category: CommandCategory.A32NX,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'FlyByWire A32NX | Remote MCDU',
+        description: 'Please see our [guide](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/web-mcdu/) on how to use the FlyByWire A32NX remote MCDU feature.',
+    })),
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -88,6 +88,7 @@ import { assistance } from './a32nx/assistance';
 import { ctd } from './support/ctd';
 import { hud } from './support/hud';
 import { fms } from './funnies/fms';
+import { mcdu } from './a32nx/mcdu';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -178,6 +179,7 @@ const commands: CommandDefinition[] = [
     ctd,
     hud,
     fms,
+    mcdu,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};


### PR DESCRIPTION
## Description

add remote .mcdu command to link to a32nx remote mcdu feature guide
aliases: .mcdu, .remotemcdu, .remote

## Test Results

![image](https://user-images.githubusercontent.com/93292288/147892861-f9469809-8c89-4912-a51f-b72229a334c1.png)

## Discord Username

Earthsam12#5545
