### PR TITLE
feat: Add .takeoff command

### DIFF
--- a/src/commands/a32nx/takeoffPerf.ts
+++ b/src/commands/a32nx/takeoffPerf.ts
@@ -12,6 +12,7 @@ export const takeoffPerf: CommandDefinition = {
         , 
         'While there are many online calculators available, these often use A320ceo data, and are not accurate.'
         , 
-        , 'This unfortunately means that we cannot provide a reliable and accurate takeoff performance calculator for the A32NX until Airbus releases the data, or we find another way.']),
+       ' ', 
+       'This unfortunately means that we cannot provide a reliable and accurate takeoff performance calculator for the A32NX until Airbus releases the data, or we find another way.']),
     })),
 };

--- a/src/commands/a32nx/takeoffPerf.ts
+++ b/src/commands/a32nx/takeoffPerf.ts
@@ -1,0 +1,17 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed, makeLines } from '../../lib/embed';
+
+export const takeoffPerf: CommandDefinition = {
+    name: ['takeoff', 'calculator', 'perf'],
+    description: 'Provides an explaination as to why there is no takeoff calculator for V-speeds or FLEX.',
+    category: CommandCategory.A32NX,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'Where is the takeoff calculator?',
+        description: makeLines(['Currently, Airbus does not publicly release takeoff performance data for the A320neo, which means it is impossible to create an accurate takeoff calculator.', 
+        , 
+        'While there are many online calculators available, these often use A320ceo data, and are not accurate.'
+        , 
+        , 'This unfortunately means that we cannot provide a reliable and accurate takeoff performance calculator for the A32NX until Airbus releases the data, or we find another way.']),
+    })),
+};

--- a/src/commands/a32nx/takeoffPerf.ts
+++ b/src/commands/a32nx/takeoffPerf.ts
@@ -8,11 +8,11 @@ export const takeoffPerf: CommandDefinition = {
     category: CommandCategory.A32NX,
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'Where is the takeoff calculator?',
-        description: makeLines(['Currently, Airbus does not publicly release takeoff performance data for the A320neo, which means it is impossible to create an accurate takeoff calculator.', 
+        description: makeLines(['Currently, Airbus does not publicly release takeoff performance data for the A320neo, which means it is difficult to create an accurate takeoff calculator.', 
         ' ', 
         'While there are many online calculators available, these often use A320ceo data, and are not accurate.'
         , 
        ' ', 
-       'This unfortunately means that we cannot provide a reliable and accurate takeoff performance calculator for the A32NX until Airbus releases the data, or we find another way.']),
+       'This unfortunately means that we cannot provide a reliable and accurate takeoff performance calculator at this time.']),
     })),
 };

--- a/src/commands/a32nx/takeoffPerf.ts
+++ b/src/commands/a32nx/takeoffPerf.ts
@@ -4,7 +4,7 @@ import { makeEmbed, makeLines } from '../../lib/embed';
 
 export const takeoffPerf: CommandDefinition = {
     name: ['takeoff', 'calculator', 'perf'],
-    description: 'Provides an explaination as to why there is no takeoff calculator for V-speeds or FLEX.',
+    description: 'Provides an explanation as to why there is no takeoff calculator for V-speeds or FLEX.',
     category: CommandCategory.A32NX,
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'FlyByWire A32NX | Where is the takeoff calculator?',

--- a/src/commands/a32nx/takeoffPerf.ts
+++ b/src/commands/a32nx/takeoffPerf.ts
@@ -7,7 +7,7 @@ export const takeoffPerf: CommandDefinition = {
     description: 'Provides an explaination as to why there is no takeoff calculator for V-speeds or FLEX.',
     category: CommandCategory.A32NX,
     executor: (msg) => msg.channel.send(makeEmbed({
-        title: 'Where is the takeoff calculator?',
+        title: 'FlyByWire A32NX | Where is the takeoff calculator?',
         description: makeLines(['Currently, Airbus does not publicly release takeoff performance data for the A320neo, which means it is difficult to create an accurate takeoff calculator.', 
         '', 
         'While there are many online calculators available, these often use A320ceo data, and are not accurate.' ,

--- a/src/commands/a32nx/takeoffPerf.ts
+++ b/src/commands/a32nx/takeoffPerf.ts
@@ -9,10 +9,9 @@ export const takeoffPerf: CommandDefinition = {
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'Where is the takeoff calculator?',
         description: makeLines(['Currently, Airbus does not publicly release takeoff performance data for the A320neo, which means it is difficult to create an accurate takeoff calculator.', 
-        ' ', 
-        'While there are many online calculators available, these often use A320ceo data, and are not accurate.'
-        , 
-       ' ', 
+        '', 
+        'While there are many online calculators available, these often use A320ceo data, and are not accurate.' ,
+        '', 
        'This unfortunately means that we cannot provide a reliable and accurate takeoff performance calculator at this time.']),
     })),
 };

--- a/src/commands/a32nx/takeoffPerf.ts
+++ b/src/commands/a32nx/takeoffPerf.ts
@@ -12,6 +12,6 @@ export const takeoffPerf: CommandDefinition = {
         '', 
         'While there are many online calculators available, these often use A320ceo data, and are not accurate.' ,
         '', 
-       'This unfortunately means that we cannot provide a reliable and accurate takeoff performance calculator at this time.']),
+        'This unfortunately means that we cannot provide a reliable and accurate takeoff performance calculator at this time.']),
     })),
 };

--- a/src/commands/a32nx/takeoffPerf.ts
+++ b/src/commands/a32nx/takeoffPerf.ts
@@ -9,7 +9,7 @@ export const takeoffPerf: CommandDefinition = {
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'Where is the takeoff calculator?',
         description: makeLines(['Currently, Airbus does not publicly release takeoff performance data for the A320neo, which means it is impossible to create an accurate takeoff calculator.', 
-        , 
+        ' ', 
         'While there are many online calculators available, these often use A320ceo data, and are not accurate.'
         , 
        ' ', 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -89,6 +89,7 @@ import { ctd } from './support/ctd';
 import { hud } from './support/hud';
 import { fms } from './funnies/fms';
 import { mcdu } from './a32nx/mcdu';
+import { takeoffPerf } from './a32nx/takeoffPerf';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -180,6 +181,7 @@ const commands: CommandDefinition[] = [
     hud,
     fms,
     mcdu,
+    takeoffPerf,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};


### PR DESCRIPTION
## Description

Adds a .takeoff (.calculator, .perf) command which explains why there is no takeoff performance calculator available.

## Test Results

![image](https://user-images.githubusercontent.com/93292288/148324166-910cfafa-7146-4785-b68d-fee88d4bbb61.png)

## Discord Username

Earthsam12#5545
