### PR TITLE
fix: messagedelete handler now includes deleted images

### DIFF
--- a/src/handlers/messagedelete.ts
+++ b/src/handlers/messagedelete.ts
@@ -14,51 +14,30 @@ export const messageDeleted: EventHandlerDefinition<[Message]> = {
         const userLogsChannel = message.guild.channels.resolve(Channels.USER_LOGS) as TextChannel | null;
 
         if (!UserLogExclude.some((e) => e === message.author.id) && userLogsChannel !== null) {
+            const deleteEmbed = makeEmbed({
+                color: 'RED',
+                thumbnail: { url: 'https://cdn.discordapp.com/attachments/770835189419999262/779946282373873694/150-1509174_deleted-message-icon-sign-hd-png-download.png' },
+                author: {
+                    name: message.author.tag,
+                    icon_url: message.author.displayAvatarURL({ dynamic: true }),
+                },
+                fields: [
+                    { name: 'Author', value: message.author, inline: true },
+                    { name: 'Channel', value: `<#${message.channel.id}>`, inline: true },
+                ],
+                footer: { text: `User ID: ${message.author.id}` },
+            });
+
             if (message.attachments.size > 0 && message.content) {
-                await userLogsChannel.send(makeEmbed({
-                    color: 'RED',
-                    thumbnail: { url: 'https://cdn.discordapp.com/attachments/770835189419999262/779946282373873694/150-1509174_deleted-message-icon-sign-hd-png-download.png' },
-                    author: {
-                        name: message.author.tag,
-                        icon_url: message.author.displayAvatarURL({ dynamic: true }),
-                    },
-                    fields: [
-                        { name: 'Author', value: message.author, inline: true },
-                        { name: 'Channel', value: `<#${message.channel.id}>`, inline: true },
-                        { name: 'Deleted message', value: message.content, inline: false },
-                        { name: 'Deleted Image', value: message.attachments.first().url, inline: false },
-                    ],
-                    footer: { text: `User ID: ${message.author.id}` },
-                }));
+                deleteEmbed.fields[2] = { name: 'Deleted Message', value: message.content, inline: false };
+                deleteEmbed.fields[3] = { name: 'Deleted Image', value: message.attachments.first().url, inline: false };
+                await userLogsChannel.send(deleteEmbed);
             } else if (message.attachments.size > 0) {
-                await userLogsChannel.send(makeEmbed({
-                    color: 'RED',
-                    thumbnail: { url: 'https://cdn.discordapp.com/attachments/770835189419999262/779946282373873694/150-1509174_deleted-message-icon-sign-hd-png-download.png' },
-                    author: {
-                        name: message.author.tag,
-                        icon_url: message.author.displayAvatarURL({ dynamic: true }),
-                    },
-                    fields: [
-                        { name: 'Author', value: message.author, inline: true },
-                        { name: 'Channel', value: `<#${message.channel.id}>`, inline: true },
-                        { name: 'Deleted Image', value: message.attachments.first().url, inline: false },
-                    ],
-                    footer: { text: `User ID: ${message.author.id}` },
-                }));
+                deleteEmbed.fields[2] = { name: 'Deleted Image', value: message.attachments.first().url, inline: false };
+                await userLogsChannel.send(deleteEmbed);
             } else {
-                await userLogsChannel.send(makeEmbed({
-                    color: 'RED',
-                    thumbnail: { url: 'https://cdn.discordapp.com/attachments/770835189419999262/779946282373873694/150-1509174_deleted-message-icon-sign-hd-png-download.png' },
-                    author: {
-                        name: message.author.tag,
-                        icon_url: message.author.displayAvatarURL({ dynamic: true }),
-                    },
-                    fields: [
-                        { name: 'Author', value: message.author, inline: true },
-                        { name: 'Channel', value: `<#${message.channel.id}>`, inline: false},
-                        { name: 'Deleted Message', value: message.content, inline: false },
-                    ]
-                }))
+                deleteEmbed.fields[2] = { name: 'Deleted Message', value: message.content, inline: false };
+                await userLogsChannel.send(deleteEmbed);
             }
         }
     },

--- a/src/handlers/messagedelete.ts
+++ b/src/handlers/messagedelete.ts
@@ -41,7 +41,7 @@ export const messageDeleted: EventHandlerDefinition<[Message]> = {
                     fields: [
                         { name: 'Author', value: message.author, inline: true },
                         { name: 'Channel', value: `<#${message.channel.id}>`, inline: true },
-                        { name: 'Deleted Message', value: message.attachments.first().url, inline: false },
+                        { name: 'Deleted Image', value: message.attachments.first().url, inline: false },
                     ],
                     footer: { text: `User ID: ${message.author.id}` },
                 }));

--- a/src/handlers/messagedelete.ts
+++ b/src/handlers/messagedelete.ts
@@ -3,8 +3,6 @@ import { EventHandlerDefinition } from '../lib/handler';
 import { Channels, UserLogExclude } from '../constants';
 import { makeEmbed } from '../lib/embed';
 
-const FEATURE_NOT_AVAIL = '(can\'t show embeds or images)';
-
 export const messageDeleted: EventHandlerDefinition<[Message]> = {
     event: 'messageDelete',
     executor: async (message) => {
@@ -16,20 +14,52 @@ export const messageDeleted: EventHandlerDefinition<[Message]> = {
         const userLogsChannel = message.guild.channels.resolve(Channels.USER_LOGS) as TextChannel | null;
 
         if (!UserLogExclude.some((e) => e === message.author.id) && userLogsChannel !== null) {
-            await userLogsChannel.send(makeEmbed({
-                color: 'RED',
-                thumbnail: { url: 'https://cdn.discordapp.com/attachments/770835189419999262/779946282373873694/150-1509174_deleted-message-icon-sign-hd-png-download.png' },
-                author: {
-                    name: message.author.tag,
-                    icon_url: message.author.displayAvatarURL({ dynamic: true }),
-                },
-                fields: [
-                    { name: 'Author', value: message.author, inline: true },
-                    { name: 'Channel', value: `<#${message.channel.id}>`, inline: true },
-                    { name: 'Deleted Message', value: message.content ? `\`\`\`${message.content}\`\`\`` : FEATURE_NOT_AVAIL, inline: false },
-                ],
-                footer: { text: `User ID: ${message.author.id}` },
-            }));
+            if (message.attachments.size > 0 && message.content) {
+                await userLogsChannel.send(makeEmbed({
+                    color: 'RED',
+                    thumbnail: { url: 'https://cdn.discordapp.com/attachments/770835189419999262/779946282373873694/150-1509174_deleted-message-icon-sign-hd-png-download.png' },
+                    author: {
+                        name: message.author.tag,
+                        icon_url: message.author.displayAvatarURL({ dynamic: true }),
+                    },
+                    fields: [
+                        { name: 'Author', value: message.author, inline: true },
+                        { name: 'Channel', value: `<#${message.channel.id}>`, inline: true },
+                        { name: 'Deleted message', value: message.content, inline: false },
+                        { name: 'Deleted Image', value: message.attachments.first().url, inline: false },
+                    ],
+                    footer: { text: `User ID: ${message.author.id}` },
+                }));
+            } else if (message.attachments.size > 0) {
+                await userLogsChannel.send(makeEmbed({
+                    color: 'RED',
+                    thumbnail: { url: 'https://cdn.discordapp.com/attachments/770835189419999262/779946282373873694/150-1509174_deleted-message-icon-sign-hd-png-download.png' },
+                    author: {
+                        name: message.author.tag,
+                        icon_url: message.author.displayAvatarURL({ dynamic: true }),
+                    },
+                    fields: [
+                        { name: 'Author', value: message.author, inline: true },
+                        { name: 'Channel', value: `<#${message.channel.id}>`, inline: true },
+                        { name: 'Deleted Message', value: message.attachments.first().url, inline: false },
+                    ],
+                    footer: { text: `User ID: ${message.author.id}` },
+                }));
+            } else {
+                await userLogsChannel.send(makeEmbed({
+                    color: 'RED',
+                    thumbnail: { url: 'https://cdn.discordapp.com/attachments/770835189419999262/779946282373873694/150-1509174_deleted-message-icon-sign-hd-png-download.png' },
+                    author: {
+                        name: message.author.tag,
+                        icon_url: message.author.displayAvatarURL({ dynamic: true }),
+                    },
+                    fields: [
+                        { name: 'Author', value: message.author, inline: true },
+                        { name: 'Channel', value: `<#${message.channel.id}>`, inline: false},
+                        { name: 'Deleted Message', value: message.content, inline: false },
+                    ]
+                }))
+            }
         }
     },
 };


### PR DESCRIPTION
## Description

Previously the deleted messages sent to #userlogs wouldn't include images. This fixes that. Messages deleted that included that image should now include a link to that image in userlogs. 

## Test Results

![image](https://user-images.githubusercontent.com/81839029/149548250-4efb3e56-753f-4a68-83d6-52fe4cd46f2b.png)

## Discord Username

oim#0001
