### PR TITLE
feat: added wasm command

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -92,6 +92,7 @@ import { mcdu } from './a32nx/mcdu';
 import { takeoffPerf } from './a32nx/takeoffPerf';
 import { manualleg } from './support/manualleg';
 import { oim } from './funnies/oim';
+import { wasm } from './support/wasm';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -186,6 +187,7 @@ const commands: CommandDefinition[] = [
     takeoffPerf,
     manualleg,
     oim,
+    wasm,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};

--- a/src/commands/support/wasm.ts
+++ b/src/commands/support/wasm.ts
@@ -1,0 +1,13 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed } from '../../lib/embed';
+
+export const wasm: CommandDefinition = {
+    name: ['wasm', 'load'],
+    description: 'Explains the long loading times after an install or update',
+    category: CommandCategory.SUPPORT,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'FlyByWire Support | Long loading times',
+        description: 'The first load after installing or updating the addon will take a while due to WASM being compiled. This is normal and may take up to 10 minutes or longer.',
+    })),
+};


### PR DESCRIPTION
## Description

Requested by boris for support purposes. Explains the long loading times that users may encounter after a first install/update. Aliases are .wasm and .load

## Test Results

![image](https://user-images.githubusercontent.com/81839029/151666920-358c7110-6eb8-4a8f-b247-2a30009e7edd.png)

## Discord Username

oim#0001
