### PR TITLE
feat: SimBrief integration command

### DIFF
--- a/src/commands/a32nx/simbriefimport.ts
+++ b/src/commands/a32nx/simbriefimport.ts
@@ -2,8 +2,6 @@ import { CommandDefinition } from '../../lib/command';
 import { makeEmbed, makeLines } from '../../lib/embed';
 import { CommandCategory } from '../../constants';
 
-const SIMBRIEF_INTEGRATION_IMAGE_URL = 'https://cdn.discordapp.com/attachments/945012754589298721/945056041656279130/unknown.png';
-
 export const simbriefimport: CommandDefinition = {
     name: ['import', 'integration', 'integ'],
     description: 'Shows how to use SimBrief integration',
@@ -11,8 +9,7 @@ export const simbriefimport: CommandDefinition = {
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'FlyByWire A32NX | SimBrief import',
         description: makeLines([
-            'The A32NX has SimBrief integration. This means you can create a flight plan in SimBrief and import it into the MCDU! Please refer to our [documentation](https://docs.flybywiresim.com/pilots-corner/beginner-guide/preflight/#flight-plan-import) for instructions. (The image below is how it will look once everything has been set up properly)',
+            'The A32NX has SimBrief integration. This means you can create a flight plan in SimBrief and import it into the MCDU! Please refer to our [documentation](https://docs.flybywiresim.com/pilots-corner/beginner-guide/preflight/#flight-plan-import) for instructions.',
         ]),
-        image: { url: SIMBRIEF_INTEGRATION_IMAGE_URL},
     })),
 };

--- a/src/commands/a32nx/simbriefimport.ts
+++ b/src/commands/a32nx/simbriefimport.ts
@@ -11,7 +11,7 @@ export const simbriefimport: CommandDefinition = {
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'FlyByWire A32NX | SimBrief import',
         description: makeLines([
-            'The A32NX has SimBrief integration, and you can create a flight plan in SimBrief and import it into the MCDU. There are some steps involved in doing this, so please refer to our documentation on more information. https://docs.flybywiresim.com/pilots-corner/beginner-guide/preflight/#flight-plan-import (The image below is how it will look once everything has been set up properly)'
+            'The A32NX has SimBrief integration. This means you can create a flight plan in SimBrief and import it into the MCDU! Please refer to our [documentation](https://docs.flybywiresim.com/pilots-corner/beginner-guide/preflight/#flight-plan-import) for instructions. (The image below is how it will look once everything has been set up properly)',
         ]),
         image: { url: SIMBRIEF_INTEGRATION_IMAGE_URL},
     })),

--- a/src/commands/a32nx/simbriefimport.ts
+++ b/src/commands/a32nx/simbriefimport.ts
@@ -6,7 +6,7 @@ const SIMBRIEF_INTEGRATION_IMAGE_URL = 'https://cdn.discordapp.com/attachments/9
 
 export const simbriefimport: CommandDefinition = {
     name: ['import', 'integration', 'integ'],
-    description: 'Shows how to use SimBrief integration ',
+    description: 'Shows how to use SimBrief integration',
     category: CommandCategory.A32NX,
     executor: (msg) => msg.channel.send(makeEmbed({
         title: 'FlyByWire A32NX | SimBrief import',

--- a/src/commands/a32nx/simbriefimport.ts
+++ b/src/commands/a32nx/simbriefimport.ts
@@ -1,0 +1,18 @@
+import { CommandDefinition } from '../../lib/command';
+import { makeEmbed, makeLines } from '../../lib/embed';
+import { CommandCategory } from '../../constants';
+
+const Simbrief_request_URL = 'https://cdn.discordapp.com/attachments/945012754589298721/945056041656279130/unknown.png';
+
+export const simbriefimport: CommandDefinition = {
+    name: ['import', 'integration', 'integ'],
+    description: 'Shows how to use SimBrief integration ',
+    category: CommandCategory.A32NX,
+    executor: (msg) => msg.channel.send(makeEmbed({
+        title: 'FlyByWire A32NX | SimBrief import',
+        description: makeLines([
+            'The A32NX has SimBrief integration, and you can create a flight plan in SimBrief and import it into the MCDU. There are some steps involved in doing this, so please refer to our documentation on more information. https://docs.flybywiresim.com/pilots-corner/beginner-guide/preflight/#flight-plan-import (The image below is how it will look once everything has been set up properly)'
+        ]),
+        image: { url: Simbrief_request_URL},
+    })),
+};

--- a/src/commands/a32nx/simbriefimport.ts
+++ b/src/commands/a32nx/simbriefimport.ts
@@ -13,6 +13,6 @@ export const simbriefimport: CommandDefinition = {
         description: makeLines([
             'The A32NX has SimBrief integration, and you can create a flight plan in SimBrief and import it into the MCDU. There are some steps involved in doing this, so please refer to our documentation on more information. https://docs.flybywiresim.com/pilots-corner/beginner-guide/preflight/#flight-plan-import (The image below is how it will look once everything has been set up properly)'
         ]),
-        image: { url: Simbrief_request_URL},
+        image: { url: SIMBRIEF_INTEGRATION_IMAGE_URL},
     })),
 };

--- a/src/commands/a32nx/simbriefimport.ts
+++ b/src/commands/a32nx/simbriefimport.ts
@@ -2,7 +2,7 @@ import { CommandDefinition } from '../../lib/command';
 import { makeEmbed, makeLines } from '../../lib/embed';
 import { CommandCategory } from '../../constants';
 
-const Simbrief_request_URL = 'https://cdn.discordapp.com/attachments/945012754589298721/945056041656279130/unknown.png';
+const SIMBRIEF_INTEGRATION_IMAGE_URL = 'https://cdn.discordapp.com/attachments/945012754589298721/945056041656279130/unknown.png';
 
 export const simbriefimport: CommandDefinition = {
     name: ['import', 'integration', 'integ'],

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -94,8 +94,9 @@ import { manualleg } from './support/manualleg';
 import { oim } from './funnies/oim';
 import { wasm } from './support/wasm';
 import { CPDLC } from './a32nx/CPDLC';
-
+import {simbriefimport} from './a32nx/simbriefimport';
 const commands: CommandDefinition[] = [
+    simbriefimport,
     ping,
     help,
     bruheg,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -96,7 +96,6 @@ import { wasm } from './support/wasm';
 import { CPDLC } from './a32nx/CPDLC';
 import {simbriefimport} from './a32nx/simbriefimport';
 const commands: CommandDefinition[] = [
-    simbriefimport,
     ping,
     help,
     bruheg,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -94,6 +94,7 @@ import { manualleg } from './support/manualleg';
 import { oim } from './funnies/oim';
 import { wasm } from './support/wasm';
 import { CPDLC } from './a32nx/CPDLC';
+
 import {simbriefimport} from './a32nx/simbriefimport';
 const commands: CommandDefinition[] = [
     ping,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -94,8 +94,8 @@ import { manualleg } from './support/manualleg';
 import { oim } from './funnies/oim';
 import { wasm } from './support/wasm';
 import { CPDLC } from './a32nx/CPDLC';
+import { simbriefimport } from './a32nx/simbriefimport';
 
-import {simbriefimport} from './a32nx/simbriefimport';
 const commands: CommandDefinition[] = [
     ping,
     help,
@@ -191,6 +191,7 @@ const commands: CommandDefinition[] = [
     oim,
     wasm,
     CPDLC,
+    simbriefimport,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};


### PR DESCRIPTION
feat: SimBrief integration command


The command shows users how to use SimBrief integration, with an image showing how it will look when everything is done correctly, and to the docs referring to how to set it up.  Commands are: import, integration,  integ


<img width="636" alt="image" src="https://user-images.githubusercontent.com/88508303/154867319-f9fba87e-c408-4740-8477-29908e533ee5.png">



zx#0671


