### PR TITLE
feat: .timeout

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -97,6 +97,7 @@ import { CPDLC } from './a32nx/cpdlc';
 import { simbriefimport } from './a32nx/simbriefimport';
 import { roleassignment } from './moderation/roleassignment';
 import { timeout } from './moderation/timeout';
+import { untimeout } from './moderation/untimeout';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -196,6 +197,7 @@ const commands: CommandDefinition[] = [
     simbriefimport,
     roleassignment,
     timeout,
+    untimeout,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -96,6 +96,7 @@ import { wasm } from './support/wasm';
 import { CPDLC } from './a32nx/cpdlc';
 import { simbriefimport } from './a32nx/simbriefimport';
 import { roleassignment } from './moderation/roleassignment';
+import { timeout } from './moderation/timeout';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -193,7 +194,8 @@ const commands: CommandDefinition[] = [
     wasm,
     CPDLC,
     simbriefimport,
-    roleassignment
+    roleassignment,
+    timeout,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};

--- a/src/commands/moderation/timeout.ts
+++ b/src/commands/moderation/timeout.ts
@@ -2,6 +2,13 @@ import { CommandDefinition } from '../../lib/command';
 import { CommandCategory } from '../../constants';
 import { makeEmbed } from '../../lib/embed';
 
+enum TimeConversions {
+    MINUTES_TO_MILLISECONDS = 60 * 1000,
+    HOURS_TO_MILLISECONDS = 60 * 60 * 1000,
+    DAYS_TO_MILLISECONDS = 60 * 60 * 24 * 1000,
+    WEEKS_TO_MILLISECONDS = 60 * 60 * 24 * 7 * 1000,
+}
+
 export const timeout: CommandDefinition = {
     name: 'timeout',
     requiredPermissions: ['BAN_MEMBERS'],
@@ -15,10 +22,31 @@ export const timeout: CommandDefinition = {
 
         const id = args[0];
         const user = await msg.guild.members.fetch(id);
-        const timeoutLength = parseInt(args[1]);
+        const timeoutArg = args[1];
         const reason = args[2];
 
-        await user.timeout(timeoutLength * 60 * 1000, reason);
+        let timeoutLength: number;
+        switch (timeoutArg[timeoutArg.length-1]) {
+            default: {
+                // defaults to minutes; 'm' will also run this block
+                timeoutLength = parseInt(timeoutArg.slice(0, timeoutArg.length - 1)) * TimeConversions.MINUTES_TO_MILLISECONDS;
+                break;
+            }
+            case 'h': {
+                timeoutLength = parseInt(timeoutArg.slice(0, timeoutArg.length - 1)) * TimeConversions.HOURS_TO_MILLISECONDS;
+                break;
+            }
+            case 'd': {
+                timeoutLength = parseInt(timeoutArg.slice(0, timeoutArg.length - 1)) * TimeConversions.DAYS_TO_MILLISECONDS;
+                break;
+            }
+            case 'w': {
+                timeoutLength = parseInt(timeoutArg.slice(0, timeoutArg.length - 1)) * TimeConversions.WEEKS_TO_MILLISECONDS;
+                break;
+            }
+        }
+
+        await user.timeout(timeoutLength, reason);
         await msg.channel.send(
             {
                 embeds: [makeEmbed({

--- a/src/commands/moderation/timeout.ts
+++ b/src/commands/moderation/timeout.ts
@@ -1,0 +1,48 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed } from '../../lib/embed';
+
+export const timeout: CommandDefinition = {
+    name: 'timeout',
+    requiredPermissions: ['BAN_MEMBERS'],
+    category: CommandCategory.MODERATION,
+    executor: async (msg) => {
+        const args = msg.content.replace(/\.timeout\s+/, '').split(' ');
+        if (args.length < 3) {
+            await msg.reply('You need to provide the following arguments for this command: <id> <timeoutLength> <reason>');
+            return;
+        }
+
+        const id = args[0];
+        const user = await msg.guild.members.fetch(id);
+        const timeoutLength = parseInt(args[1]);
+        const reason = args[2];
+
+        await user.timeout(timeoutLength * 60 * 1000, reason);
+        await msg.channel.send(
+            {
+                embeds: [makeEmbed({
+                    title: 'User Successfully Timed Out',
+                    fields: [
+                        {
+                            inline: true,
+                            name: 'User',
+                            value: user.toString(),
+                        },
+                        {
+                            inline: true,
+                            name: 'ID',
+                            value: id,
+                        },
+                        {
+                            inline: false,
+                            name: 'Reason',
+                            value: reason,
+                        },
+                    ],
+                    color: 'GREEN',
+                })],
+            },
+        );
+    },
+};

--- a/src/commands/moderation/timeout.ts
+++ b/src/commands/moderation/timeout.ts
@@ -9,6 +9,18 @@ enum TimeConversions {
     WEEKS_TO_MILLISECONDS = 60 * 60 * 24 * 7 * 1000,
 }
 
+const DMEmbed = () => makeEmbed({
+    // stuff
+});
+
+const modLogEmbed = () => makeEmbed({
+    // sutff
+});
+
+const timeoutEmbed = () => makeEmbed({
+    // stuff
+});
+
 export const timeout: CommandDefinition = {
     name: 'timeout',
     requiredPermissions: ['BAN_MEMBERS'],
@@ -47,6 +59,7 @@ export const timeout: CommandDefinition = {
         }
 
         await user.timeout(timeoutLength, reason);
+        // todo: check if successful
         await msg.channel.send(
             {
                 embeds: [makeEmbed({

--- a/src/commands/moderation/timeout.ts
+++ b/src/commands/moderation/timeout.ts
@@ -30,7 +30,7 @@ const timeoutDurationInEnglish = (timeoutDurationString: string) => {
     return `${timeoutDurationNumber} ${word}`;
 };
 
-const DMEmbed = (moderator: User, timeoutDuration: string, reason: string, guild: Guild) => makeEmbed({
+const DMEmbed = (moderator: User, timeoutDuration: string, reason: string, guild: Guild, timedOutUntil: Date) => makeEmbed({
     title: `You were muted in ${guild.name}`,
     author: {
         name: guild.name,
@@ -54,6 +54,7 @@ const DMEmbed = (moderator: User, timeoutDuration: string, reason: string, guild
             value: reason,
         },
     ],
+    footer: { text: `Your timeout will be lifted on ${timedOutUntil.toUTCString()}` },
 });
 
 const timeoutEmbed = (user: User, reason: string, timeoutDuration: string) => makeEmbed({
@@ -150,9 +151,9 @@ export const timeout: CommandDefinition = {
         }
 
         await targetUser.timeout(timeoutDuration, reason);
-        // todo: check if successful
         await msg.channel.send({ embeds: [timeoutEmbed(targetUser.user, reason, timeoutArg)] });
         await modLogsChannel.send({ embeds: [modLogEmbed(msg.author, targetUser.user, reason, timeoutArg)] });
-        await targetUser.send({ embeds: [DMEmbed(msg.author, timeoutArg, reason, msg.guild)] });
+        await targetUser.send({ embeds: [DMEmbed(msg.author, timeoutArg, reason, msg.guild, targetUser.communicationDisabledUntil)] });
+        // todo: error checking
     },
 };

--- a/src/commands/moderation/timeout.ts
+++ b/src/commands/moderation/timeout.ts
@@ -10,6 +10,26 @@ enum TimeConversions {
     WEEKS_TO_MILLISECONDS = 60 * 60 * 24 * 7 * 1000,
 }
 
+const timeoutDurationInEnglish = (timeoutDurationString: string) => {
+    timeoutDurationString = timeoutDurationString.toLowerCase();
+    const unitOfTimeWords = ['minute', 'hour', 'day', 'week'];
+    const unitOfTimeAbbreviations = ['m', 'h', 'd', 'w'];
+    const timeoutDurationNumber = parseInt(timeoutDurationString);
+
+    let word!: string;
+    for (const i of unitOfTimeAbbreviations) {
+        if (timeoutDurationString.indexOf(i) !== -1) {
+            word = unitOfTimeWords[unitOfTimeAbbreviations.indexOf(i)];
+            break;
+        }
+    }
+    if (!word) {
+        word = unitOfTimeWords[0]; // 'minute'
+    }
+    word += (timeoutDurationNumber > 1 || timeoutDurationNumber === 0 ? 's' : ''); // Determines plurality
+    return `${timeoutDurationNumber} ${word}`;
+};
+
 const DMEmbed = (moderator: User, timeoutDuration: string, reason: string, guild: Guild) => makeEmbed({
     title: `You were muted in ${guild.name}`,
     author: {
@@ -21,7 +41,7 @@ const DMEmbed = (moderator: User, timeoutDuration: string, reason: string, guild
         {
             inline: true,
             name: 'Duration',
-            value: timeoutDuration,
+            value: timeoutDurationInEnglish(timeoutDuration),
         },
         {
             inline: true,
@@ -57,7 +77,7 @@ const timeoutEmbed = (user: User, reason: string, timeoutDuration: string) => ma
         {
             inline: true,
             name: 'Duration',
-            value: timeoutDuration,
+            value: timeoutDurationInEnglish(timeoutDuration),
         },
     ],
     color: 'GREEN',
@@ -84,7 +104,7 @@ const modLogEmbed = (moderator: User, user: User, reason: string, timeoutDuratio
         },
         {
             name: 'Duration',
-            value: timeoutDuration,
+            value: timeoutDurationInEnglish(timeoutDuration),
         },
     ],
     timestamp: Date.now(),
@@ -110,23 +130,23 @@ export const timeout: CommandDefinition = {
 
         let timeoutDuration: number;
         switch (timeoutArg[timeoutArg.length - 1].toLowerCase()) {
-            default: {
-                // defaults to minutes; 'm' will also run this block
-                timeoutDuration = parseInt(timeoutArg.replace('m', '')) * TimeConversions.MINUTES_TO_MILLISECONDS;
-                break;
-            }
-            case 'h': {
-                timeoutDuration = parseInt(timeoutArg.replace('h', '')) * TimeConversions.HOURS_TO_MILLISECONDS;
-                break;
-            }
-            case 'd': {
-                timeoutDuration = parseInt(timeoutArg.replace('d', '')) * TimeConversions.DAYS_TO_MILLISECONDS;
-                break;
-            }
-            case 'w': {
-                timeoutDuration = parseInt(timeoutArg.replace('w', '')) * TimeConversions.WEEKS_TO_MILLISECONDS;
-                break;
-            }
+        default: {
+            // defaults to minutes; 'm' will also run this block
+            timeoutDuration = parseInt(timeoutArg.replace('m', '')) * TimeConversions.MINUTES_TO_MILLISECONDS;
+            break;
+        }
+        case 'h': {
+            timeoutDuration = parseInt(timeoutArg.replace('h', '')) * TimeConversions.HOURS_TO_MILLISECONDS;
+            break;
+        }
+        case 'd': {
+            timeoutDuration = parseInt(timeoutArg.replace('d', '')) * TimeConversions.DAYS_TO_MILLISECONDS;
+            break;
+        }
+        case 'w': {
+            timeoutDuration = parseInt(timeoutArg.replace('w', '')) * TimeConversions.WEEKS_TO_MILLISECONDS;
+            break;
+        }
         }
 
         await targetUser.timeout(timeoutDuration, reason);

--- a/src/commands/moderation/timeout.ts
+++ b/src/commands/moderation/timeout.ts
@@ -1,6 +1,7 @@
 import { CommandDefinition } from '../../lib/command';
 import { CommandCategory } from '../../constants';
 import { makeEmbed } from '../../lib/embed';
+import { GuildMember } from 'discord.js';
 
 enum TimeConversions {
     MINUTES_TO_MILLISECONDS = 60 * 1000,
@@ -13,11 +14,34 @@ const DMEmbed = () => makeEmbed({
     // stuff
 });
 
-const modLogEmbed = () => makeEmbed({
-    // sutff
+const timeoutEmbed = (user: GuildMember, reason: string, timeoutLength: string) => makeEmbed({
+    title: 'User Successfully Timed Out',
+    fields: [
+        {
+            inline: true,
+            name: 'User',
+            value: user.toString(),
+        },
+        {
+            inline: true,
+            name: 'ID',
+            value: user.id,
+        },
+        {
+            inline: false,
+            name: 'Reason',
+            value: reason,
+        },
+        {
+            inline: true, // TODO: move this field to the second row somehow?
+            name: 'Timeout Length',
+            value: timeoutLength,
+        },
+    ],
+    color: 'GREEN',
 });
 
-const timeoutEmbed = () => makeEmbed({
+const modLogEmbed = () => makeEmbed({
     // stuff
 });
 
@@ -35,13 +59,13 @@ export const timeout: CommandDefinition = {
         const id = args[0];
         const user = await msg.guild.members.fetch(id);
         const timeoutArg = args[1];
-        const reason = args[2];
+        const reason = args.slice(2).join(' ');
 
         let timeoutLength: number;
-        switch (timeoutArg[timeoutArg.length-1]) {
+        switch (timeoutArg[timeoutArg.length - 1]) {
             default: {
                 // defaults to minutes; 'm' will also run this block
-                timeoutLength = parseInt(timeoutArg.slice(0, timeoutArg.length - 1)) * TimeConversions.MINUTES_TO_MILLISECONDS;
+                timeoutLength = parseInt(timeoutArg.replace('m', '')) * TimeConversions.MINUTES_TO_MILLISECONDS;
                 break;
             }
             case 'h': {
@@ -60,30 +84,6 @@ export const timeout: CommandDefinition = {
 
         await user.timeout(timeoutLength, reason);
         // todo: check if successful
-        await msg.channel.send(
-            {
-                embeds: [makeEmbed({
-                    title: 'User Successfully Timed Out',
-                    fields: [
-                        {
-                            inline: true,
-                            name: 'User',
-                            value: user.toString(),
-                        },
-                        {
-                            inline: true,
-                            name: 'ID',
-                            value: id,
-                        },
-                        {
-                            inline: false,
-                            name: 'Reason',
-                            value: reason,
-                        },
-                    ],
-                    color: 'GREEN',
-                })],
-            },
-        );
+        await msg.channel.send({ embeds: [timeoutEmbed(user, reason, timeoutArg)] });
     },
 };

--- a/src/commands/moderation/timeout.ts
+++ b/src/commands/moderation/timeout.ts
@@ -16,9 +16,7 @@ const DMEmbed = (moderator: User, timeoutDuration: string, reason: string, guild
         name: guild.name,
         icon_url: guild.iconURL(),
     },
-    thumbnail: {
-        url: moderator.avatarURL(),
-    },
+    thumbnail: { url: moderator.avatarURL() },
     fields: [
         {
             inline: true,
@@ -57,7 +55,7 @@ const timeoutEmbed = (user: User, reason: string, timeoutDuration: string) => ma
             value: reason,
         },
         {
-            inline: true, // TODO: move this field to the second row somehow?
+            inline: true,
             name: 'Duration',
             value: timeoutDuration,
         },
@@ -118,15 +116,15 @@ export const timeout: CommandDefinition = {
                 break;
             }
             case 'h': {
-                timeoutDuration = parseInt(timeoutArg.slice(0, timeoutArg.length - 1)) * TimeConversions.HOURS_TO_MILLISECONDS;
+                timeoutDuration = parseInt(timeoutArg.replace('h', '')) * TimeConversions.HOURS_TO_MILLISECONDS;
                 break;
             }
             case 'd': {
-                timeoutDuration = parseInt(timeoutArg.slice(0, timeoutArg.length - 1)) * TimeConversions.DAYS_TO_MILLISECONDS;
+                timeoutDuration = parseInt(timeoutArg.replace('d', '')) * TimeConversions.DAYS_TO_MILLISECONDS;
                 break;
             }
             case 'w': {
-                timeoutDuration = parseInt(timeoutArg.slice(0, timeoutArg.length - 1)) * TimeConversions.WEEKS_TO_MILLISECONDS;
+                timeoutDuration = parseInt(timeoutArg.replace('w', '')) * TimeConversions.WEEKS_TO_MILLISECONDS;
                 break;
             }
         }

--- a/src/commands/moderation/timeout.ts
+++ b/src/commands/moderation/timeout.ts
@@ -31,7 +31,7 @@ const timeoutDurationInEnglish = (timeoutDurationString: string) => {
 };
 
 const DMEmbed = (moderator: User, timeoutDuration: string, reason: string, guild: Guild, timedOutUntil: Date) => makeEmbed({
-    title: `You were muted in ${guild.name}`,
+    title: `You were timed out in ${guild.name}`,
     author: {
         name: guild.name,
         icon_url: guild.iconURL(),

--- a/src/commands/moderation/timeout.ts
+++ b/src/commands/moderation/timeout.ts
@@ -111,7 +111,7 @@ export const timeout: CommandDefinition = {
         const reason = args.slice(2).join(' ');
 
         let timeoutDuration: number;
-        switch (timeoutArg[timeoutArg.length - 1]) {
+        switch (timeoutArg[timeoutArg.length - 1].toLowerCase()) {
             default: {
                 // defaults to minutes; 'm' will also run this block
                 timeoutDuration = parseInt(timeoutArg.replace('m', '')) * TimeConversions.MINUTES_TO_MILLISECONDS;

--- a/src/commands/moderation/timeout.ts
+++ b/src/commands/moderation/timeout.ts
@@ -182,7 +182,9 @@ export const timeout: CommandDefinition = {
             if (targetUser.isCommunicationDisabled()) { // Timeout successful
                 const timeoutResponse = await msg.channel.send({ embeds: [timeoutEmbed(targetUser.user, reason, timeoutArg)] });
                 await targetUser.send({ embeds: [DMEmbed(msg.author, timeoutArg, reason, msg.guild, targetUser.communicationDisabledUntil)] });
-                await modLogsChannel.send({ embeds: [modLogEmbed(msg.author, targetUser.user, reason, timeoutArg)] });
+                if (modLogsChannel) {
+                    await modLogsChannel.send({ embeds: [modLogEmbed(msg.author, targetUser.user, reason, timeoutArg)] });
+                }
                 return setTimeout(() => { // Delete the command and response after 4 seconds
                     timeoutResponse.delete();
                     msg.delete();

--- a/src/commands/moderation/untimeout.ts
+++ b/src/commands/moderation/untimeout.ts
@@ -1,0 +1,74 @@
+import { Guild, TextChannel, User } from 'discord.js';
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory, Channels } from '../../constants';
+import { makeEmbed } from '../../lib/embed';
+
+export const unTimeoutDMEmbed = (moderator: User, guild: Guild) => makeEmbed({
+    author: {
+        name: guild.name,
+        icon_url: guild.iconURL(),
+    },
+    title: `Your timeout was removed in ${guild.name}`,
+    description: `Your timeout was removed in ${guild.name}. You may chat, react and join voice chats once again.`,
+    footer: { iconURL: moderator.avatarURL(), text: `Timeout removed by ${moderator.tag}` },
+});
+
+export const unTimeoutEmbed = (user: User) => makeEmbed({
+    title: 'Successfully Removed Timeout',
+    fields: [
+        {
+            inline: true,
+            name: 'User',
+            value: user.toString(),
+        },
+        {
+            inline: true,
+            name: 'ID',
+            value: user.id,
+        },
+    ],
+    color: 'GREEN',
+});
+
+export const unTimeoutModLogEmbed = (moderator: User, user: User) => makeEmbed({
+    color: 'GREEN',
+    author: {
+        name: `[REMOVED TIMEOUT] ${user.tag}`,
+        icon_url: user.displayAvatarURL({ dynamic: true }),
+    },
+    fields: [
+        {
+            name: 'Member',
+            value: user.toString(),
+        },
+        {
+            name: 'Moderator',
+            value: `<@${moderator}>`,
+        },
+    ],
+    timestamp: Date.now(),
+    footer: { text: `User ID: ${user.id}` },
+});
+
+export const untimeout: CommandDefinition = {
+    name: ['untimeout', 'removetimeout'],
+    requiredPermissions: ['BAN_MEMBERS'],
+    category: CommandCategory.MODERATION,
+    executor: async (msg) => {
+        const args = msg.content.replace(/\.untimeout\s+/, '').split(' ');
+        if (args.length < 1) {
+            await msg.reply('You need to provide the following arguments for this command: <id>');
+            return;
+        }
+
+        const modLogsChannel = msg.guild.channels.resolve(Channels.MOD_LOGS) as TextChannel | null;
+        const id = args[0];
+        const targetUser = await msg.guild.members.fetch(id);
+
+        await targetUser.timeout(0);
+        await msg.channel.send({ embeds: [unTimeoutEmbed(targetUser.user)] });
+        await modLogsChannel.send({ embeds: [unTimeoutModLogEmbed(msg.author, targetUser.user)] });
+        await targetUser.send({ embeds: [unTimeoutDMEmbed(msg.author, msg.guild)] });
+        // todo: error checking
+    },
+};

--- a/src/commands/moderation/untimeout.ts
+++ b/src/commands/moderation/untimeout.ts
@@ -83,11 +83,15 @@ export const untimeout: CommandDefinition = {
         const id = args[0];
         const targetUser: GuildMember = await msg.guild.members.fetch(id);
 
-        targetUser.timeout(0).then(() => {
+        targetUser.timeout(0).then(async () => {
             if (targetUser.isCommunicationDisabled() === false) {
-                msg.channel.send({ embeds: [unTimeoutEmbed(targetUser.user)] });
-                modLogsChannel.send({ embeds: [unTimeoutModLogEmbed(msg.author, targetUser.user)] });
-                return targetUser.send({ embeds: [unTimeoutDMEmbed(msg.author, msg.guild)] });
+                const timeoutResponse = await msg.channel.send({ embeds: [unTimeoutEmbed(targetUser.user)] });
+                await targetUser.send({ embeds: [unTimeoutDMEmbed(msg.author, msg.guild)] });
+                await modLogsChannel.send({ embeds: [unTimeoutModLogEmbed(msg.author, targetUser.user)] });
+                return setTimeout(() => {
+                    timeoutResponse.delete();
+                    msg.delete();
+                }, 4000);
             }
             return msg.channel.send({ embeds: [failedUnTimeoutEmbed(targetUser.user)] });
         });

--- a/src/commands/moderation/untimeout.ts
+++ b/src/commands/moderation/untimeout.ts
@@ -83,7 +83,9 @@ export const untimeout: CommandDefinition = {
             if (targetUser.isCommunicationDisabled() === false) {
                 const timeoutResponse = await msg.channel.send({ embeds: [unTimeoutEmbed(targetUser.user)] });
                 await targetUser.send({ embeds: [unTimeoutDMEmbed(msg.author, msg.guild)] });
-                await modLogsChannel.send({ embeds: [unTimeoutModLogEmbed(msg.author, targetUser.user)] });
+                if (modLogsChannel) {
+                    await modLogsChannel.send({ embeds: [unTimeoutModLogEmbed(msg.author, targetUser.user)] });
+                }
                 return setTimeout(() => {
                     timeoutResponse.delete();
                     msg.delete();

--- a/src/commands/moderation/untimeout.ts
+++ b/src/commands/moderation/untimeout.ts
@@ -4,10 +4,6 @@ import { CommandCategory, Channels } from '../../constants';
 import { makeEmbed } from '../../lib/embed';
 
 export const unTimeoutDMEmbed = (moderator: User, guild: Guild) => makeEmbed({
-    author: {
-        name: guild.name,
-        icon_url: guild.iconURL(),
-    },
     title: `Your timeout was removed in ${guild.name}`,
     description: `Your timeout was removed in ${guild.name}. You may chat, react and join voice chats once again.`,
     footer: { iconURL: moderator.avatarURL(), text: `Timeout removed by ${moderator.tag}` },


### PR DESCRIPTION
## Description

Implements the discord timeouts feature in a .timeout command. 

Tasks: 
- [x] timeout user
- [x] dm'ing the user
- [x] put amount of time user was timed out for in embed
- [x] allowing the moderator to type something like 1w (one week timeout) or 3d (three day timeout) instead of only being allowed to set timeout in minutes
- [x] send message in modlogs
- [x] englishify timeout duration
- [x] show when timeout will be lifted
- [ ] ~~modlog message for manual (right click) timeouts~~ (not possible due to lack of discord event for timeouts)
- [x] some error checking

Some limitations:
 * There is no event for timeouts being added or removed. Therefore, it's not feasible to create an event handler for timeouts (to account for right-click timeouts). This can come at a later time if an event becomes available.
 * Removing a timeout is done by setting 0 for timeout duration. There is no official 'remove timeout' method for GuildMember. This is how discord itself handles removing timeouts.
 * Maximum timeout length is 3 weeks. Discord.js / API restriction.

## Test Results

Timeout command + response: 
![image](https://user-images.githubusercontent.com/93292288/157163771-fd586b40-aecc-45a7-8993-c4c94abd8fb5.png)

Message sent to user when timed out:
![image](https://user-images.githubusercontent.com/93292288/157163743-ae4af493-1b9b-40d5-b60c-0fc9f775753b.png)

Message sent in modlogs when timeout set by the bot
![image](https://user-images.githubusercontent.com/93292288/157163798-3c8bb689-048f-46a0-afb5-1ee99c39ecb7.png)

Removing timeout via setting 0-length timeout (msg. 1) or using .untimeout (msg. 2): 
![image](https://user-images.githubusercontent.com/93292288/157163781-3358862a-67bb-4499-91c6-3c59309ada96.png)

Message sent to user when timeout removed:
![image](https://user-images.githubusercontent.com/93292288/157163754-29a449bb-31d2-42df-87db-0687e6691c34.png)

Message sent in modlogs when timeout removed from user by the bot: 
![image](https://user-images.githubusercontent.com/93292288/157163787-a4220bf1-aae4-4438-9f9c-36a2f1c2bdb3.png)

Message sent when attempting to timeout a user for more than 3 weeks (discord.js/api limit, not mine):
![image](https://user-images.githubusercontent.com/93292288/157164217-e0c7a720-cfb7-4b29-b61b-483e70f4ec21.png)


## Discord Username

Earthsam12#5545