### PR TITLE
fix: message delete/update crash

### DIFF
--- a/src/handlers/messagedelete.ts
+++ b/src/handlers/messagedelete.ts
@@ -12,6 +12,11 @@ module.exports = {
             return;
         }
 
+        if (message.content === null) {
+            // Old Message
+            return;
+        }
+
         const userLogsChannel = message.guild.channels.resolve(Channels.USER_LOGS) as TextChannel | null;
 
         if (userLogsChannel && !UserLogExclude.some((e) => e === message.author.id)) {

--- a/src/handlers/messageupdate.ts
+++ b/src/handlers/messageupdate.ts
@@ -7,6 +7,15 @@ const FEATURE_NOT_AVAIL = '(can\'t show embeds or images)';
 module.exports = {
     event: 'messageUpdate',
     executor: async (oldMessage, newMessage) => {
+        if (oldMessage.guild === null) {
+            // DMs
+            return;
+        }
+
+        if (oldMessage.content === null) {
+            // Old Message
+            return;
+        }
 
         const userLogsChannel = oldMessage.guild.channels.resolve(Channels.USER_LOGS) as TextChannel | null;
 


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description

This PR fixes a crash when an `old message` is deleted or updated. The message is not cached by the bot, therefore it can't receive message content, author etc. This fix will ignore the message if the content of the message = null. The message content is null due to `old message` not cached. 

`old message` refers to a message that has been sent before the bot has been brought online.

<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results

N/A

Tested locally and in a docker container. Both working.

<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username

BenW#8484

<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
