### PR TITLE
refactor: update commands that reference status of experimental branch

### DIFF
--- a/src/commands/a32nx/experimental.ts
+++ b/src/commands/a32nx/experimental.ts
@@ -1,6 +1,6 @@
 import { CommandDefinition } from '../../lib/command';
 import { CommandCategory } from '../../constants';
-import { makeEmbed } from '../../lib/embed';
+import { makeEmbed, makeLines } from '../../lib/embed';
 
 export const experimental: CommandDefinition = {
     name: ['experimental', 'exp'],
@@ -9,8 +9,11 @@ export const experimental: CommandDefinition = {
     executor: async (msg) => {
         const experimentalEmbed = makeEmbed({
             title: 'FlyByWire A32NX | Experimental Version',
-            description: 'We are currently testing updates to our custom FMS LNAV, and other additional improvements. Please see our [Experimental Version Support Page](https://docs.flybywiresim.com/fbw-a32nx/support/exp/) for more information. **No support will be offered via Discord.** '
-                + 'The Experimental version is a test version to find problems and issues and to improve functionality based on your feedback. It is not meant to be used for daily use or when you try to do a serious flight on an Online ATC service. '
+            description: makeLines([
+                'Currently experimental is undergoing updates that can break the aircraft and is not 100% ready for public use. All previous features have been moved to our development version. Please see our [Experimental Version Support Page](https://docs.flybywiresim.com/fbw-a32nx/support/exp/) for more information. **No support will be offered via Discord.** ',
+                '',
+                'The Experimental version is a test version to find problems and issues and to improve functionality based on your feedback. It is not meant to be used for daily use or when you try to do a serious flight on an Online ATC service. ',
+            ]),
         });
 
         await msg.channel.send({ embeds: [experimentalEmbed] });

--- a/src/commands/a32nx/versions.ts
+++ b/src/commands/a32nx/versions.ts
@@ -1,6 +1,6 @@
 import { CommandDefinition } from '../../lib/command';
 import { CommandCategory } from '../../constants';
-import { makeEmbed } from '../../lib/embed';
+import { makeEmbed, makeLines } from '../../lib/embed';
 
 export const versions: CommandDefinition = {
     name: 'versions',
@@ -34,8 +34,11 @@ export const versions: CommandDefinition = {
                 },
                 {
                     name: 'Experimental',
-                    value: '> We are currently testing updates to our custom FMS LNAV, and other additional improvements. Please see our [Experimental Version Support Page](https://docs.flybywiresim.com/fbw-a32nx/support/exp/) for more information. **No support will be offered via Discord.** '
-                        + 'The Experimental version is a test version to find problems and issues and to improve functionality based on your feedback. It is not meant to be used for daily use or when you try to do a serious flight on an Online ATC service. ',
+                    value: makeLines([
+                        '> Currently experimental is undergoing updates that can break the aircraft and is not 100% ready for public use. All previous features have been moved to our development version. Please see our [Experimental Version Support Page](https://docs.flybywiresim.com/fbw-a32nx/support/exp/) for more information. **No support will be offered via Discord.** ',
+                        '> ',
+                        '> The Experimental version is a test version to find problems and issues and to improve functionality based on your feedback. It is not meant to be used for daily use or when you try to do a serious flight on an Online ATC service. ',
+                    ]),
                     inline: false,
                 },
             ],


### PR DESCRIPTION
## Description

Updates to `experimental.ts` and `versions.ts` to reflect the current status of the experimental branch.

Both commands I've imported `makeLines` to break up the copy and make it a little more readable. See indicated line breaks in screenshot below.

Commands are in support of docs PR below. Please notify docs team when moving commands to production.
- https://github.com/flybywiresim/docs/pull/468

## Test Results

![image](https://user-images.githubusercontent.com/1619968/156913457-d924df65-3ec4-46e0-ae1b-39e105dc7a4b.png)

## Discord Username

Valastiri#8902
