### PR TITLE
feat: tcas command

### DIFF
--- a/src/commands/a32nx/tcas.ts
+++ b/src/commands/a32nx/tcas.ts
@@ -1,0 +1,26 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed, makeLines } from '../../lib/embed';
+
+export const tcas: CommandDefinition = {
+    name: 'tcas',
+    description: 'Provides support information about A32NX AP/FD TCAS',
+    category: CommandCategory.A32NX,
+    executor: async (msg) => {
+        const tcasEmbed = makeEmbed({
+            title: 'FlyByWire A32NX | AP/FD TCAS',
+            description: makeLines([
+                'The A32NX is capable of handling TA/RAs while on an ATC network such as VATSIM/IVAO '
+                + 'or with the live traffic feature in MSFS. ',
+                '',
+                'Our implementation utilizes AP/FD TCAS by Airbus which allows for Autopilot controlled corrective maneuvers. ',
+                '',
+                'For details on how the system functions, known issues, and pilot actions see our '
+                + '[**Advanced Guide: TCAS**](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/tcas/). ',
+             ]),
+        });
+
+        await msg.channel.send({ embeds: [tcasEmbed] });
+
+    },
+};

--- a/src/commands/a32nx/tcas.ts
+++ b/src/commands/a32nx/tcas.ts
@@ -10,13 +10,14 @@ export const tcas: CommandDefinition = {
         const tcasEmbed = makeEmbed({
             title: 'FlyByWire A32NX | AP/FD TCAS',
             description: makeLines([
-                'The A32NX is capable of handling TA/RAs while on an ATC network such as VATSIM/IVAO '
+                'The A32NX utilizes AP/FD TCAS by Airbus which allows for fully automated flight for both '
+                + 'traffic advisories (TA) and resolution advisories (RA). ',
+                '',
+                'Our implementation is capable of handling TA/RAs while on an ATC network such as VATSIM/IVAO '
                 + 'or with the live traffic feature in MSFS. ',
                 '',
-                'Our implementation utilizes AP/FD TCAS by Airbus which allows for Autopilot controlled corrective maneuvers. ',
-                '',
                 'For details on how the system functions, known issues, and pilot actions see our '
-                + '[**Advanced Guide: TCAS**](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/tcas/). ',
+                + '[Advanced Guide: TCAS](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/tcas/). ',
              ]),
         });
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -102,6 +102,7 @@ import { audio } from './a32nx/audio';
 import { flexTemp } from './a32nx/flex-temp';
 import { preflight } from './a32nx/preflight';
 import { storedWaypoint } from './a32nx/stored-waypoint';
+import { tcas } from './a32nx/tcas';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -205,7 +206,8 @@ const commands: CommandDefinition[] = [
     audio,
     flexTemp,
     preflight,
-    storedWaypoint
+    storedWaypoint,
+    tcas
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};


### PR DESCRIPTION
## Description

**Note** - Please wait for docs PR:
- https://github.com/flybywiresim/docs/pull/472

Provides a snapshot of A32NX AP/FD TCAS and links to the expanded documentation on the feature.

## Test Results

![image](https://user-images.githubusercontent.com/1619968/159184153-38abe0fe-b5a7-4093-9597-04d7b9c2bf7d.png)

## Discord Username

Valastiri#8902