### PR TITLE
fix: metar/station command error handling

### DIFF
--- a/src/commands/utils/metar.ts
+++ b/src/commands/utils/metar.ts
@@ -21,31 +21,49 @@ export const metar: CommandDefinition = {
             headers: {
                 Authorization: process.env.METAR_TOKEN },
         }, async (error, response, body) => {
-            const metarReport = JSON.parse(body);
-            const metarEmbed = makeEmbed({
-                title: `METAR Report | ${metarReport.station}`,
-                description: makeLines([
-                    '**Raw Report**',
-                    metarReport.raw,
-                    ,
-                    '**Basic Report:**',
-                    `**Time Observed:** ${metarReport.time.dt}`,
-                    `**Station:** ${metarReport.station}`,
-                    `**Wind:** ${metarReport.wind_direction.repr} at ${metarReport.wind_speed.repr}kts`,
-                    `**Visibility:** ${metarReport.visibility.repr}${metarReport.units.visibility}`,
-                    `**Temperature:** ${metarReport.temperature.repr}C`,
-                    `**Dew Point:** ${metarReport.dewpoint.repr}C`,
-                    `**Altimeter:** ${metarReport.altimeter.value.toString()} ${metarReport.units.altimeter}`,
-                ]),
-                fields: [
-                    {
-                        name: 'Unsure of how to read the raw report?',
-                        value: 'Please refer to our guide [here.](https://docs.flybywiresim.com/pilots-corner/airliner-flying-guide/weather/)',
-                        inline: false
-                    },
-                ],
-                footer: { text: 'This METAR report may not accurately reflect the weather in the simulator. However, it will always be similar to the current conditions present in the sim.' },
-            });
+            let metarEmbed;
+
+            if(response.statusCode == 200) {
+                const metarReport = JSON.parse(body);
+                metarEmbed = makeEmbed({
+                    title: `METAR Report | ${metarReport.station}`,
+                    description: makeLines([
+                        '**Raw Report**',
+                        metarReport.raw,
+                        ,
+                        '**Basic Report:**',
+                        `**Time Observed:** ${metarReport.time.dt}`,
+                        `**Station:** ${metarReport.station}`,
+                        `**Wind:** ${metarReport.wind_direction.repr} at ${metarReport.wind_speed.repr}kts`,
+                        `**Visibility:** ${metarReport.visibility.repr}${metarReport.units.visibility}`,
+                        `**Temperature:** ${metarReport.temperature.repr}C`,
+                        `**Dew Point:** ${metarReport.dewpoint.repr}C`,
+                        `**Altimeter:** ${metarReport.altimeter.value.toString()} ${metarReport.units.altimeter}`,
+                    ]),
+                    fields: [
+                        {
+                            name: 'Unsure of how to read the raw report?',
+                            value: 'Please refer to our guide [here.](https://docs.flybywiresim.com/pilots-corner/airliner-flying-guide/weather/)',
+                            inline: false
+                        },
+                    ],
+                    footer: { text: 'This METAR report may not accurately reflect the weather in the simulator. However, it will always be similar to the current conditions present in the sim.' },
+                });
+            } else if(response.statusCode == 400) {
+                metarEmbed = makeEmbed({
+                    title: `METAR Error | ${icaoArg.toUpperCase()}`,
+                    description: makeLines([
+                        `${icaoArg.toUpperCase()} is not a valid station code!`,
+                    ]),
+                });
+            } else {
+                metarEmbed = makeEmbed({
+                    title: `METAR Error`,
+                    description: makeLines([
+                        `There was an unknown error with the METAR request!`,
+                    ]),
+                });
+            }
 
             await msg.channel.send({ embeds: [metarEmbed] });
 

--- a/src/commands/utils/metar.ts
+++ b/src/commands/utils/metar.ts
@@ -24,6 +24,7 @@ export const metar: CommandDefinition = {
             let metarEmbed;
 
             if(response.statusCode == 200) {
+                // Response OK, parse the JSON
                 const metarReport = JSON.parse(body);
                 metarEmbed = makeEmbed({
                     title: `METAR Report | ${metarReport.station}`,
@@ -50,6 +51,7 @@ export const metar: CommandDefinition = {
                     footer: { text: 'This METAR report may not accurately reflect the weather in the simulator. However, it will always be similar to the current conditions present in the sim.' },
                 });
             } else if(response.statusCode == 400) {
+                // Invalid ICAO/IATA code
                 metarEmbed = makeEmbed({
                     title: `METAR Error | ${icaoArg.toUpperCase()}`,
                     description: makeLines([
@@ -57,6 +59,7 @@ export const metar: CommandDefinition = {
                     ]),
                 });
             } else {
+                // Unknown error
                 metarEmbed = makeEmbed({
                     title: `METAR Error`,
                     description: makeLines([

--- a/src/commands/utils/station.ts
+++ b/src/commands/utils/station.ts
@@ -21,35 +21,55 @@ export const station: CommandDefinition = {
             headers: {
                 Authorization: process.env.STATION_TOKEN },
         }, async (error, response, body) => {
+            let stationEmbed;
 
-            const stationReport = JSON.parse(body);
+            if(response.statusCode == 200) {
+                // Response OK, parse the JSON
+                const stationReport = JSON.parse(body);
 
-            const runwayIdents = stationReport.runways.map((runways) => {
-                return `**${runways.ident1}/${runways.ident2}:** `
-                    +`${runways.length_ft} ft x ${runways.width_ft} ft / `
-                    +`${Math.round(runways.length_ft * 0.3048)} m x ${Math.round(runways.width_ft * 0.3048)} m`;
-            });
+                const runwayIdents = stationReport.runways.map((runways) => {
+                    return `**${runways.ident1}/${runways.ident2}:** `
+                        +`${runways.length_ft} ft x ${runways.width_ft} ft / `
+                        +`${Math.round(runways.length_ft * 0.3048)} m x ${Math.round(runways.width_ft * 0.3048)} m`;
+                });
 
-            const stationEmbed = makeEmbed({
-                title: `Station info | ${stationReport.icao}`,
-                description: makeLines([
-                    '**Station Information:**',
-                    `**Name:** ${stationReport.name}`,
-                    `**Country:** ${stationReport.country}`,
-                    `**City:** ${stationReport.city}`,
-                    `**Latitude:** ${stationReport.latitude}°`,
-                    `**Longitude:** ${stationReport.longitude}°`,
-                    `**Elevation:** ${stationReport.elevation_m} m/${stationReport.elevation_ft} ft`,
-                    ,
-                    `**Runways (Ident1/Ident2: Length x Width):**`,
-                    `${runwayIdents.toString( ).replace(/,/g,"\n")}`,
-                    ,
-                    `**Type:** ${stationReport.type.replace(/_/g," ")}`,
-                    `**Website:** ${stationReport.website}`,
-                    `**Wiki:** ${stationReport.wiki}`,
-                ]),
-                footer: { text: 'Due to limitations of the API, not all links may be up to date at all times.' }
-            });
+                stationEmbed = makeEmbed({
+                    title: `Station Info | ${stationReport.icao}`,
+                    description: makeLines([
+                        '**Station Information:**',
+                        `**Name:** ${stationReport.name}`,
+                        `**Country:** ${stationReport.country}`,
+                        `**City:** ${stationReport.city}`,
+                        `**Latitude:** ${stationReport.latitude}°`,
+                        `**Longitude:** ${stationReport.longitude}°`,
+                        `**Elevation:** ${stationReport.elevation_m} m/${stationReport.elevation_ft} ft`,
+                        ,
+                        `**Runways (Ident1/Ident2: Length x Width):**`,
+                        `${runwayIdents.toString( ).replace(/,/g,"\n")}`,
+                        ,
+                        `**Type:** ${stationReport.type.replace(/_/g," ")}`,
+                        `**Website:** ${stationReport.website}`,
+                        `**Wiki:** ${stationReport.wiki}`,
+                    ]),
+                    footer: { text: 'Due to limitations of the API, not all links may be up to date at all times.' }
+                });
+            } else if(response.statusCode == 400) {
+                // Invalid ICAO/IATA code
+                stationEmbed = makeEmbed({
+                    title: `Station Error | ${icaoArg.toUpperCase()}`,
+                    description: makeLines([
+                        `${icaoArg.toUpperCase()} is not a valid station code!`,
+                    ]),
+                });
+            } else {
+                // Unknown error
+                stationEmbed = makeEmbed({
+                    title: `Station Error`,
+                    description: makeLines([
+                        `There was an unknown error with the station request!`,
+                    ]),
+                });
+            }
 
             await msg.channel.send({ embeds: [stationEmbed] });
 


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description

Current implementation of the METAR & station commands do not properly handle erroneous responses from the AVWX API, and cause the bot to restart if any are received (see below for behavior). Normal response codes include 200 (response OK) and 400 (client error, in this case invalid ICAO/IATA code). This implements a check on the response status code, avoiding a crash caused by attempting to access body fields that do not exist in erroneous responses.

![image](https://user-images.githubusercontent.com/64386329/162917079-7ba37ee1-9bad-40a8-9ad7-3dd8be89aff1.png)

## Test Results

![image](https://user-images.githubusercontent.com/64386329/162916418-bab803ae-804b-4938-b7ca-196bc7f35578.png)

## Discord Username

pererry#8489
