### PR TITLE
refactor(clean): remove search query string from hyperlink

### DIFF
--- a/src/commands/support/clean-install.ts
+++ b/src/commands/support/clean-install.ts
@@ -10,7 +10,7 @@ export const clean: CommandDefinition = {
         const cleanEmbed = makeEmbed({
             title: 'FlyByWire A32NX | Clean Install',
             description: makeLines([
-                'We suggest trying a clean install. Please see [this guide](https://docs.flybywiresim.com/fbw-a32nx/installation/?h=clean+install#clean-install-steps) for detailed instructions.',
+                'We suggest trying a clean install. Please see [this guide](https://docs.flybywiresim.com/fbw-a32nx/installation/#clean-install-steps) for detailed instructions.',
             ]),
         });
 


### PR DESCRIPTION
## Description

The original link had the mkdocs-material `/?h=clean+install` search query in the hyperlink causing highlighting across the page which may be distracting for readers since there's a dedicated anchor link available.

## Test Results

For posterity - link works in testing.

![cleaninstallpr](https://user-images.githubusercontent.com/1619968/163231733-f6c34549-655f-4b2c-89f5-e73b8f61f84a.png)
## Discord Username

Valastiri#8902
