### PR TITLE
Refactor: Updated synaptic discord invite link 

### DIFF
--- a/src/commands/general/synaptic.ts
+++ b/src/commands/general/synaptic.ts
@@ -6,7 +6,7 @@ export const synaptic: CommandDefinition = {
     description: 'Provides link to synaptic discord server',
     category: CommandCategory.GENERAL,
     executor: async (msg) => {
-        await msg.channel.send('https://discord.gg/acQkSvrePG');
+        await msg.channel.send('https://discord.gg/synaptic');
         await msg.delete();
     },
 };

--- a/src/commands/general/synaptic.ts
+++ b/src/commands/general/synaptic.ts
@@ -7,6 +7,5 @@ export const synaptic: CommandDefinition = {
     category: CommandCategory.GENERAL,
     executor: async (msg) => {
         await msg.channel.send('https://discord.gg/synaptic');
-        
     },
 };

--- a/src/commands/general/synaptic.ts
+++ b/src/commands/general/synaptic.ts
@@ -7,6 +7,6 @@ export const synaptic: CommandDefinition = {
     category: CommandCategory.GENERAL,
     executor: async (msg) => {
         await msg.channel.send('https://discord.gg/synaptic');
-        await msg.delete();
+        
     },
 };


### PR DESCRIPTION
Updated synaptic.ts with the new vanity url. Aliases are still .synaptic and .syn

![image](https://user-images.githubusercontent.com/88508303/165008628-1cc21e27-4e41-4bb4-8ca3-4cbf4457a8c8.png)


zx#0671