### PR TITLE
fix: reword .xbox command and change category

### DIFF
--- a/src/commands/general/xbox.ts
+++ b/src/commands/general/xbox.ts
@@ -5,11 +5,11 @@ import { makeEmbed } from '../../lib/embed';
 export const xbox: CommandDefinition = {
     name: ['xbox', 'xboxmarketplace'],
     description: 'Short response + link to NOTAM for xbox marketplace',
-    category: CommandCategory.A32NX,
+    category: CommandCategory.GENERAL,
     executor: async (msg) => {
         const xboxEmbed = makeEmbed({
-            title: 'FlyByWire A32NX | Xbox + MSFS Marketplace',
-            description: 'Due to a number of contributing factors, the A32NX will not be released on the Xbox or the Marketplace. [You can read more here](https://flybywiresim.com/notams/marketplace-announcement/).',
+            title: 'FlyByWire Addons | Xbox + MSFS Marketplace',
+            description: 'Due to a number of contributing factors, FlyByWire addons will not be released on the Xbox or the Marketplace. [You can read more here](https://flybywiresim.com/notams/marketplace-announcement/).',
         });
 
         await msg.channel.send({ embeds: [xboxEmbed] });

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -35,7 +35,7 @@ import { briefing } from './a32nx/briefing';
 import { boris } from './funnies/boris';
 import { afloor } from './a32nx/afloor';
 import { airframe } from './a32nx/airframe';
-import { xbox } from './a32nx/xbox';
+import { xbox } from './general/xbox';
 import { willithave } from './general/willithave';
 import { faq } from './moderation/faq';
 import { community } from './support/community';


### PR DESCRIPTION
## Description

Reword the .xbox command so that it applies to all FlyByWire addons and change category from A32NX to General

## Test Results

![image](https://user-images.githubusercontent.com/93292288/166165361-3712bef4-9fad-44ea-9cc8-f1e47dab8d3e.png)

## Discord Username

Earthsam12#5545
