### PR TITLE
fix: update .synaptic with non-vanity link

### DIFF
--- a/src/commands/general/synaptic.ts
+++ b/src/commands/general/synaptic.ts
@@ -6,6 +6,6 @@ export const synaptic: CommandDefinition = {
     description: 'Provides link to synaptic discord server',
     category: CommandCategory.GENERAL,
     executor: async (msg) => {
-        await msg.channel.send('https://discord.gg/synaptic');
+        await msg.channel.send('https://discord.gg/acQkSvrePG');
     },
 };


### PR DESCRIPTION
## Description

Update the synaptic command to a non vanity permanent invite link due to synaptic losing their level 3 boost. 

## Test Results

![image](https://user-images.githubusercontent.com/81839029/168531033-1f42dc6d-b908-47f2-b989-94eed5985195.png)

## Discord Username

oim#0001
