### PR TITLE
refactor: add .ninjo as an alias to salty command

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ May 2022</small>
 
+- refactor: add .ninjo alias to .salty (16/05/2022)
 - feat: add birthday command (12/05/2022)
 - refactor: weight and balance command (11/05/2022)
 - feat: recommended settings command (11/05/2022)

--- a/.github/command-docs.md
+++ b/.github/command-docs.md
@@ -77,10 +77,10 @@
 | .headwind    | Provides link to the Headwind Discord server                                                                   | .hw                      |
 | .installer   | Provides link to the new installer                                                                             | ---                      |
 | .latlong     | Provides a cheat sheet for conversion between Latitude and longitude coordinates between short and long format | .llfix                   |
-| .msfsdisc    | Provides link to Microsoft Flight Simulator discord server                                                     | .fsdisc <br> msfsdiscord |
+| .msfsdisc    | Provides link to Microsoft Flight Simulator discord server                                                     | .fsdisc <br> .msfsdiscord|
 | .qa          | Links to the Quality Assurance docs page                                                                       | ---                      |
 | .roadmap     | FBW Roadmap                                                                                                    | .goals                   |
-| .salty       | Provides link to salty discord server                                                                          | .sal                     |
+| .salty       | Provides link to salty discord server                                                                          | .sal <br> .ninjo         |
 | .synaptic    | Provides link to synaptic discord server                                                                       | .syn                     |
 | .translate   | Provides information on how to contribute to various FlyByWire translation efforts                             | ---                      |
 | .when        | Explain the absence of release dates or ETAs                                                                   | ---                      |

--- a/src/commands/general/salty.ts
+++ b/src/commands/general/salty.ts
@@ -2,11 +2,10 @@ import { CommandDefinition } from '../../lib/command';
 import { CommandCategory } from '../../constants';
 
 export const salty: CommandDefinition = {
-    name: ['salty', 'sal'],
+    name: ['salty', 'sal', 'ninjo'],
     description: 'Provides link to salty discord server',
     category: CommandCategory.GENERAL,
     executor: async (msg) => {
         await msg.channel.send('https://discord.gg/S4PJDwk');
-        await msg.delete();
     },
 };


### PR DESCRIPTION

## Description

Adds .ninjo as an alias to the .salty command. Ninjo is the admin of Salty Simulations.

## Test Results

![image](https://user-images.githubusercontent.com/81839029/168551947-f1459094-b490-497c-8fad-6e3d26025bff.png)

## Discord Username
oim#0001
