### PR TITLE
fix: avatar command now accepts user ids

### DIFF
--- a/src/commands/utils/avatar.ts
+++ b/src/commands/utils/avatar.ts
@@ -12,7 +12,6 @@ export const avatar: CommandDefinition = {
         const user = msg.mentions.users.first() || userID || msg.author;
         user.displayAvatarURL({ dynamic: true });
         const avatarEmbed = makeEmbed({
-            title: '',
             image: { url: user.displayAvatarURL({ dynamic: true, size: 4096 }) },
         });
         if (user === msg.mentions.users.first()) {

--- a/src/commands/utils/avatar.ts
+++ b/src/commands/utils/avatar.ts
@@ -7,12 +7,21 @@ export const avatar: CommandDefinition = {
     description: 'Shows the selected user\'s avatar',
     category: CommandCategory.UTILS,
     executor: async (msg) => {
-        const user = msg.mentions.users.first() || msg.author;
+        const split = msg.content.replace(/(?:\.av|\.avatar)\s+/, '').split(' ');
+        const userID = msg.guild.members.cache.get(split[0])
+        const user = msg.mentions.users.first() || userID || msg.author;
         user.displayAvatarURL({ dynamic: true });
         const avatarEmbed = makeEmbed({
-            title: `${user.tag}'s Avatar`,
+            title: '',
             image: { url: user.displayAvatarURL({ dynamic: true, size: 4096 }) },
         });
+        if (user === msg.mentions.users.first()) {
+            avatarEmbed.title = `${user.tag}'s avatar`;
+        } else if (user === msg.author) {
+            avatarEmbed.title = `${msg.author.tag}'s avatar`;
+        } else if (user === userID) {
+            avatarEmbed.title = `${userID.user.tag}'s avatar`;
+        }
         return msg.channel.send({ embeds: [avatarEmbed] });
     },
 };

--- a/src/commands/utils/avatar.ts
+++ b/src/commands/utils/avatar.ts
@@ -11,9 +11,7 @@ export const avatar: CommandDefinition = {
         const userID = msg.guild.members.cache.get(split[0]);
         const user = msg.mentions.users.first() || userID || msg.author;
         user.displayAvatarURL({ dynamic: true });
-        const avatarEmbed = makeEmbed({
-            image: { url: user.displayAvatarURL({ dynamic: true, size: 4096 }) },
-        });
+        const avatarEmbed = makeEmbed({ image: { url: user.displayAvatarURL({ dynamic: true, size: 4096 }) } });
         if (user === msg.mentions.users.first()) {
             avatarEmbed.title = `${user.tag}'s avatar`;
         } else if (user === msg.author) {


### PR DESCRIPTION
## Description

Before this PR the avatar command did not accept user IDs. Instead it would just show the author's avatar. 

## Test Results

![image](https://user-images.githubusercontent.com/81839029/172642095-704683e1-e0fc-4189-9c30-ae67b12b2f17.png)

## Discord Username

oim#0001