### PR TITLE
chore: update eslint settings to ignore linebreak errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,6 @@
         "object-curly-newline": ["error", { "multiline": true }],
         "max-len": "off",
         "spaced-comment": "off",
-        "linebreak-style": "off"
+        "linebreak-style": ["error", "windows"]
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,7 @@
     "rules": {
         "object-curly-newline": ["error", { "multiline": true }],
         "max-len": "off",
-        "spaced-comment": "off"
+        "spaced-comment": "off",
+        "linebreak-style": "off"
     }
 }


### PR DESCRIPTION
## Description

Removes the "Expected linebreaks to be LF" error. 

## Test Results

![image](https://user-images.githubusercontent.com/81839029/173181833-dc83e19c-d0c4-401d-9c31-1365ca2e38ae.png)


## Discord Username

oim#0001
