### PR TITLE
fix: allow the use of the .removetimeout alias for .untimeout

### DIFF
--- a/src/commands/moderation/untimeout.ts
+++ b/src/commands/moderation/untimeout.ts
@@ -70,7 +70,7 @@ export const untimeout: CommandDefinition = {
     requiredPermissions: ['BAN_MEMBERS'],
     category: CommandCategory.MODERATION,
     executor: async (msg) => {
-        const args = msg.content.replace(/\.untimeout\s+/, '').split(' ');
+        const args = msg.content.replace(/(?:\.untimeout|\.removetimeout)\s+/, '').split(' ');
         if (args.length < 1) {
             await msg.reply('You need to provide the following arguments for this command: <id>');
             return;


### PR DESCRIPTION
## Description

.removetimeout is an alias for the untimeout command but would throw an error if used. This pr fixes that.

## Test Results

![image](https://user-images.githubusercontent.com/81839029/173183013-0763518f-80c4-4c44-bd03-2e011a8b16a0.png)

## Discord Username

oim#0001
