### PR TITLE
test: create verify-changelog.yml

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -23,6 +23,7 @@ Update <small>_ May 2022</small>
 - fix: reword .xbox command and change category (05/05/2022)
 - fix: Include stable in wx command (04/05/2022)
 - chore: add dependabot config (02/05/2022)
+- test: create changelog verification action (6/28/2022)
 
 Update <small>_ April 2022</small>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ June 2022</small>
 
+- ci: create changelog verification action (28/06/2022)
 - chore: update discord.js version to 13.8.0 (11/06/2022)
 - fix: allow the use of removetimeout as alias for untimeout (11/06/2022)
 - fix: avatar command now accepts user id (10/06/2022)
@@ -9,7 +10,7 @@ Update <small>_ June 2022</small>
 - refactor: add .ss as an alias to .screenshot (05/06/2022)
 - refactor: birthday permission order (01/06/2022)
 
-Update <small>_ May 2022</small>
+  Update <small>_ May 2022</small>
 
 - fix : birthday list ordering (31/05/2022)
 - refactor: update wording in .cfms (27/05/2022)
@@ -23,7 +24,6 @@ Update <small>_ May 2022</small>
 - fix: reword .xbox command and change category (05/05/2022)
 - fix: Include stable in wx command (04/05/2022)
 - chore: add dependabot config (02/05/2022)
-- test: create changelog verification action (6/28/2022)
 
 Update <small>_ April 2022</small>
 

--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -1,0 +1,69 @@
+name: Comment on the pull request
+
+on:
+  workflow_run:
+    workflows: ["Verify Changelog"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    steps:
+      - name: Download artifact
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: unzip pr.zip
+      # Need to export the variable from this step and use it in "find comment and create comment" so they can read the PR number
+      - name: Comment on PR
+        uses: actions/github-script@v3
+        id: pr
+        with:
+          script: |
+            var fs = require('fs');
+            var issue_number = Number(fs.readFileSync('./NR'));
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Find Comment
+        if: success () || failure ()
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          # issue number needs to be referenced here (not working currently)
+          issue-number: ${{ steps.pr.outputs.issue_number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Please add changelog entry. ❌
+      - name: Create comment
+        if: ${{ steps.fc.outputs.comment-id == '' && failure() }}
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          # issue number needs to be referenced here (not working currently)
+          issue-number: ${{ steps.pr.outputs.issue_number }}
+          body: |
+            Please add changelog entry. ❌
+      - name: Update comment
+        if: ${{ steps.fc.outputs.comment-id != '' && success() }}
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          body: |
+            Thank you. Changelog Verified!
+          reactions: rocket
+          edit-mode: replace

--- a/.github/workflows/verify-changelog.yml
+++ b/.github/workflows/verify-changelog.yml
@@ -24,6 +24,7 @@ jobs:
 
       # This will find and look for the specific comment in the PR. If it doesn't exist it will create it.
       - name: Find Comment
+        if: success () || failure ()
         uses: peter-evans/find-comment@v2
         id: fc
         with:
@@ -47,3 +48,4 @@ jobs:
           body: |
             Thank you. Changelog Verified!
           reactions: rocket
+          edit-mode: replace

--- a/.github/workflows/verify-changelog.yml
+++ b/.github/workflows/verify-changelog.yml
@@ -1,0 +1,49 @@
+name: Verify Changelog
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, synchronize, labeled]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    if: github.event-pull_request.draft == false
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Verify changelog
+        uses: Zomzog/changelog-checker@v1.2.0
+        with:
+          fileName: CHANGELOG.md
+          checkNotification: Simple
+          noChangelogLabel: skip changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # This will find and look for the specific comment in the PR. If it doesn't exist it will create it.
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Please add changelog entry. ❌
+      - name: Create comment
+        if: ${{ steps.fc.outputs.comment-id == '' && failure() }}
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Please add changelog entry. ❌
+            
+      # This will edit the existing comment and add the body + reaction.
+      - name: Update comment
+        if: ${{ steps.fc.outputs.comment-id != '' && success() }}
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          body: |
+            Thank you. Changelog Verified!
+          reactions: rocket

--- a/.github/workflows/verify-changelog.yml
+++ b/.github/workflows/verify-changelog.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
-    if: github.event-pull_request.draft == false
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -26,30 +25,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # This will find and look for the specific comment in the PR. If it doesn't exist it will create it.
-      - name: Find Comment
-        if: success () || failure ()
-        uses: peter-evans/find-comment@v2
-        id: fc
+  upload:
+    runs-on: ubuntu-latest
+    needs: [verify]
+    if: always ()
+    steps:
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+      - uses: actions/upload-artifact@v2
         with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Please add changelog entry. ❌
-      - name: Create comment
-        if: ${{ steps.fc.outputs.comment-id == '' && failure() }}
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            Please add changelog entry. ❌
-            
-      # This will edit the existing comment and add the body + reaction.
-      - name: Update comment
-        if: ${{ steps.fc.outputs.comment-id != '' && success() }}
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          body: |
-            Thank you. Changelog Verified!
-          reactions: rocket
-          edit-mode: replace
+          name: pr
+          path: pr/

--- a/.github/workflows/verify-changelog.yml
+++ b/.github/workflows/verify-changelog.yml
@@ -1,8 +1,12 @@
 name: Verify Changelog
 
 on:
-  pull_request_target:
-    types: [opened, ready_for_review, synchronize, labeled]
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 jobs:
   verify:


### PR DESCRIPTION
## Description

Adds a new test to ensure changelog is updated when PRs are ready for review.

Features:
- When action fails:
    -  It will add a comment in the PR: `Please add changelog entry. ❌`.
	- To prevent comment spam the action will check for the above comment before trying to add it to the PR.
- On success:
	- If the changelog was edited prior to the PR being submitted the action will not comment on the PR and simply pass the check.
	- If the action had previously failed and was re-run it will check if `Please add changelog entry. ❌` exists and update it.

Additional: If for whatever reason a changelog entry is not required there is a use case to support this (and is currently built-in via a label) - **requires label creation**

## Screenshots

PR has no changelog modifications, fails check, action will look for comment (does not exist), creates comment:
![image](https://user-images.githubusercontent.com/1619968/176077460-f80770bb-0b0a-4e8d-b184-d7339f6b2134.png)

Handling adding extra commits while not modifying changelog + comment already exists:
![image](https://user-images.githubusercontent.com/1619968/176076226-3e25410a-ff75-40e2-af96-2d46c92da7e8.png)

Sample bot message:
![image](https://user-images.githubusercontent.com/1619968/176076390-6de1ff4e-6ca2-4fd0-82b6-db75ea759760.png)

Replaced by bot upon success:
![image](https://user-images.githubusercontent.com/1619968/176076552-b314721d-7f84-4f47-8786-b251bce5d8f4.png)


## Discord Username

Valastiri#8902
