### PR TITLE
feat: add flights command

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ June 2022</small>
 
+- feat: add flights command (29/06/2022)
 - feat: add docker-compose (28/06/2022)
 - feat: adds a warn system (28/06/2022)
 - chore: update discord.js version to 13.8.0 (11/06/2022)

--- a/.github/command-docs.md
+++ b/.github/command-docs.md
@@ -139,16 +139,17 @@
 
 ### Utilities
 
-| Command         | Description                                                                            | Alias                                    |
-|:----------------|:---------------------------------------------------------------------------------------|:-----------------------------------------|
-| .avatar         | Shows the selected user's avatar                                                       | .av                                      |
-| .birthday       | Handles adding & removing user birthdays                                               | ---                                      |
-| .count          | counts in the count thread                                                             | ---                                      |
-| .help           | Sends a list of available commands to the user                                         | ---                                      |
-| .membercount    | Lists the guild's current amount of members                                            | ---                                      |
-| .metar          | Provides the METAR report of the requested airport                                     | ---                                      |
-| .ping           | Send back a message                                                                    | ---                                      |
-| .roleinfo       | Lists the guild's current amount of members                                            | ---                                      |
-| .station        | Provides station information                                                           | ---                                      |
-| .wa             | Queries the Wolfram Alpha API                                                          | .calc <br> .ask                          |
-| .zulu           | Get the current time at a given UTC-offset timezone                                    | ---                                      |
+| Command      | Description                                             | Alias                     |
+|:-------------|:--------------------------------------------------------|:--------------------------|
+| .avatar      | Shows the selected user's avatar                        | .av                       |
+| .birthday    | Handles adding & removing user birthdays                | ---                       |
+| .count       | counts in the count thread                              | ---                       |
+| .flights     | Returns the current amount of people flying with FBW.   | .stats <br/> .liveflights |
+| .help        | Sends a list of available commands to the user          | ---                       |
+| .membercount | Lists the guild's current amount of members             | ---                       |
+| .metar       | Provides the METAR report of the requested airport      | ---                       |
+| .ping        | Send back a message                                     | ---                       |
+| .roleinfo    | Lists the guild's current amount of members             | ---                       |
+| .station     | Provides station information                            | ---                       |
+| .wa          | Queries the Wolfram Alpha API                           | .calc <br> .ask           |
+| .zulu        | Get the current time at a given UTC-offset timezone     | ---                       |

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -122,6 +122,7 @@ import { recommendedSettings } from './a32nx/recommendedsettings';
 import { warn } from './moderation/warn/warn';
 import { listWarnings } from './moderation/warn/listWarnings';
 import { deleteWarn } from './moderation/warn/deleteWarn';
+import { flights } from './utils/flights';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -246,6 +247,7 @@ const commands: CommandDefinition[] = [
     warn,
     listWarnings,
     deleteWarn,
+    flights,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};

--- a/src/commands/utils/flights.ts
+++ b/src/commands/utils/flights.ts
@@ -1,0 +1,37 @@
+import request from 'request';
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed } from '../../lib/embed';
+import Logger from '../../lib/logger';
+
+export const flights: CommandDefinition = {
+    name: ['flights', 'liveflights', 'stats'],
+    description: 'Gets the flights of FlyByWire Simulations',
+    category: CommandCategory.UTILS,
+    executor: (msg) => {
+        request({
+            method: 'GET',
+            url: 'https://api.flybywiresim.com/txcxn/_count',
+        }, async (error, response, body) => {
+            if (response.statusCode === 200) {
+                const stats = JSON.parse(body);
+                const statsEmbed = makeEmbed({
+                    title: 'Current Flights',
+                    description: `**${stats}** flights`,
+                    timestamp: new Date(),
+                });
+                await msg.channel.send({ embeds: [statsEmbed] });
+            } else {
+                const errorEmbed = makeEmbed({
+                    title: 'Error - Current Flights',
+                    description: `\`\`\`${error}\`\`\``,
+                    color: 'RED',
+                });
+                Logger.error(error);
+                await msg.channel.send({ embeds: [errorEmbed] });
+            }
+        });
+
+        return Promise.resolve();
+    },
+};


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description

Adds .flights .liveflights .stats commands to return the current amount of people flying FBW.

Could add more to it and make it just a stats command for FBW if anyone has ideas.

<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results
<img width="704" alt="image" src="https://user-images.githubusercontent.com/18389085/176343496-3649eff5-176d-48aa-a731-feed859dbb48.png">

<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username
NathanI#8668
<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
