### PR TITLE
fix: remove flypad thread from exp 

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+Update <small>_ July 2022</small>
+
+- fix: remove flypados thread from .exp (07/07/2022)
+
 Update <small>_ June 2022</small>
 
 - feat: add docker-compose (28/06/2022)

--- a/src/commands/a32nx/experimental.ts
+++ b/src/commands/a32nx/experimental.ts
@@ -14,7 +14,6 @@ export const experimental: CommandDefinition = {
                 '',
                 'Please use the appropriate discord thread to discuss any issues: ',
                 '- <#926586416820011098> ',
-                '- <#957208413887139860> ',
                 '- <#965072479796215888> ',
                 '',
                 'The Experimental version is a test version to find problems, issues and to improve functionality based on your feedback. It is not meant to be used for daily use or serious flights with an Online ATC service. ',


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description
Removes flypad thread link from the .exp command.
<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results
![image](https://user-images.githubusercontent.com/87286435/177871290-9a4f8720-69d9-404e-af77-d01601a73829.png)
<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username
█▀█ █▄█ ▀█▀#2123
<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
