### PR TITLE
feat: simbridge support command

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ July 2022</small>
 
+- feat: simbridge support command (27/07/2022)
 - refactor: add steps and image to utf8 command (26/07/2022)
 - feat: cowsay command sanitization (25/07/2022)
 - refactor: update deadzones command (19/07/2022)

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -125,6 +125,7 @@ import { deleteWarn } from './moderation/warn/deleteWarn';
 import { atc } from './a32nx/atc';
 import { market } from './support/market';
 import { takeoffIssues } from './a32nx/takeoffissues';
+import { simbridge } from './support/simbridge';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -252,6 +253,7 @@ const commands: CommandDefinition[] = [
     atc,
     market,
     takeoffIssues,
+    simbridge,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};

--- a/src/commands/support/simbridge.ts
+++ b/src/commands/support/simbridge.ts
@@ -18,6 +18,6 @@ export const simbridge: CommandDefinition = {
             ]),
         });
 
-        await msg.channel.send({ embeds: [simbridgeEmbed] });
+        return msg.channel.send({ embeds: [simbridgeEmbed] });
     },
 };

--- a/src/commands/support/simbridge.ts
+++ b/src/commands/support/simbridge.ts
@@ -1,0 +1,24 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed, makeLines } from '../../lib/embed';
+
+export const simbridge: CommandDefinition = {
+    name: 'simbridge',
+    description: 'Describe SimBridge and provide support information',
+    category: CommandCategory.SUPPORT,
+    executor: async (msg) => {
+        const simbridgeEmbed = makeEmbed({
+            title: 'FlyByWire Support | SimBridge',
+            description: makeLines([
+                'SimBridge is our custom-built solution to connect our aircraft to various external devices and data. '
+                + 'It is found in the FBW Installer and ensures features will function seamlessly requiring fewer extra steps before launching into your flights.',
+                '',
+                '> **Important Note:** Please keep SimBridge updated at all times regardless of the version of aircraft you are currently flying! ',
+                '',
+                'Please [**read our documentation here**](https://docs.flybywiresim.com/simbridge) for additional information and status of associated features.',
+            ]),
+        });
+
+        await msg.channel.send({ embeds: [simbridgeEmbed] });
+    },
+};

--- a/src/commands/support/simbridge.ts
+++ b/src/commands/support/simbridge.ts
@@ -3,17 +3,16 @@ import { CommandCategory } from '../../constants';
 import { makeEmbed, makeLines } from '../../lib/embed';
 
 export const simbridge: CommandDefinition = {
-    name: 'simbridge',
+    name: ['simbridge', 'sb'],
     description: 'Describe SimBridge and provide support information',
     category: CommandCategory.SUPPORT,
     executor: async (msg) => {
         const simbridgeEmbed = makeEmbed({
             title: 'FlyByWire Support | SimBridge',
             description: makeLines([
-                'SimBridge is our custom-built solution to connect our aircraft to various external devices and data. '
-                + 'It is found in the FBW Installer and ensures features will function seamlessly requiring fewer extra steps before launching into your flights.',
+                'SimBridge is our custom-built solution to connect our aircraft to various external devices and data. It is found in the FBW Installer and ensures features will function seamlessly requiring fewer extra steps before launching into your flights.',
                 '',
-                '> **Important Note:** Please keep SimBridge updated at all times regardless of the version of aircraft you are currently flying! ',
+                '> **Important Note:** Please keep SimBridge updated at all times regardless of the version of aircraft you are currently flying!',
                 '',
                 'Please [**read our documentation here**](https://docs.flybywiresim.com/simbridge) for additional information and status of associated features.',
             ]),


### PR DESCRIPTION

## Description

Provides a short description of simbridge and utilizes copy to aid in support if users have not kept the feature updated within the installer.

Additionally provides a link to documentation. Please do not merge until the following is ready on docs:

- https://github.com/flybywiresim/docs/pull/601

---

There was a discussion between BenW and myself to put this in general. Can move if required just suddenly thought it might be more useful as a support command as discussed with Holland.

## Test Results

![sample image](https://media.discordapp.net/attachments/948504120212480012/1001622359855341659/unknown.png)

## Discord Username

Valastiri#8902