### PR TITLE
feat: add Digital Flight Dynamics Discord link command

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ July 2022</small>
 
+- feat: add Digital Flight Dynamics Discord link command (26/07/2022)
 - refactor: add steps and image to utf8 command (26/07/2022)
 - feat: cowsay command sanitization (25/07/2022)
 - refactor: update deadzones command (19/07/2022)

--- a/.github/command-docs.md
+++ b/.github/command-docs.md
@@ -74,6 +74,7 @@
 
 | Command      | Description                                                                                                    | Alias                    |
 |:-------------|:---------------------------------------------------------------------------------------------------------------|:-------------------------|
+| .dfd         | Provides link to the DFD discord server                                                                        | .digitalflightdynamics
 | .donate      | Provides a link to the open collective                                                                         | ---                      |
 | .goldenrules | Provides an image describing the golden rules an Airbus pilot should follow                                    | .golden <br> .gr         |
 | .headwind    | Provides link to the Headwind Discord server                                                                   | .hw                      |

--- a/src/commands/general/dfd.ts
+++ b/src/commands/general/dfd.ts
@@ -1,0 +1,11 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+
+export const dfd: CommandDefinition = {
+    name: ['dfd', 'digitalflightdynamics'],
+    description: 'Provides link to the DFD discord server',
+    category: CommandCategory.GENERAL,
+    executor: async (msg) => {
+        await msg.channel.send('https://discord.gg/dfd');
+    },
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -125,6 +125,7 @@ import { deleteWarn } from './moderation/warn/deleteWarn';
 import { atc } from './a32nx/atc';
 import { market } from './support/market';
 import { takeoffIssues } from './a32nx/takeoffissues';
+import { dfd } from './general/dfd';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -252,6 +253,7 @@ const commands: CommandDefinition[] = [
     atc,
     market,
     takeoffIssues,
+    dfd,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};


### PR DESCRIPTION
## Description

Provides a link to the Digital Flight Dynamics Discord server.

## Test Results

![image](https://user-images.githubusercontent.com/72813433/181141325-25b1f5a0-e2cd-4c3b-a670-c4bea1e98407.png)

## Discord Username

Dynamic#6030
