### PR TITLE
refactor: .wx command terrain display on experimental note

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ July 2022</small>
 
+- refactor: .wx command terrain display on experimental note (01/08/2022)
 - refactor: change SOP command image (01/08/2022)
 - ci: build setup and lint helm for pr (31/07/2022)
 - fix: ping fixed for count command (31/07/2022)

--- a/src/commands/a32nx/weather.ts
+++ b/src/commands/a32nx/weather.ts
@@ -10,9 +10,11 @@ export const weather: CommandDefinition = {
         const weatherEmbed = makeEmbed({
             title: 'FlyByWire A32NX | Weather Radar + Terrain Display',
             description: makeLines([
-                'All versions of the A32NX do not have an operating weather radar and terrain display. This is due to performance issues related to the default systems and the ND being rewritten.',
+                'All versions of the A32NX do not have an operating weather radar. This is due to performance issues related to the default systems and the ND being rewritten.',
                 '',
-                'The team are currently waiting on a weather and terrain API to be implemented in order to make a radar that is as realistic as possible. You can read the MSFS forum [here.](https://forums.flightsimulator.com/t/implement-weather-and-terrain-api-s-for-aircraft-developers-to-implement-accurate-radar-predictive-windshear-egpws-and-metar-wind-uplink/442016)',
+                'Terrain display is currently  only available on the experimental version via [SimBridge.](https://docs.flybywiresim.com/simbridge/)',
+                '',
+                'The team is currently waiting on a weather API to be implemented in order to make a radar that is as realistic as possible. You can read the MSFS forum [here.](https://forums.flightsimulator.com/t/implement-weather-and-terrain-api-s-for-aircraft-developers-to-implement-accurate-radar-predictive-windshear-egpws-and-metar-wind-uplink/442016)',
             ]),
         });
 


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description

Rewords the .wx command to include the note on terrain display being available on experimental. And a small grammatical correction with "The team are currently waiting..."  to "The team is currently waiting..." 

<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results

![image](https://user-images.githubusercontent.com/71195324/182168951-d57de043-c173-4d12-87f4-255a3597f9d3.png)

<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username

Imenes#6849
<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
