### PR TITLE
ci: verify changelog in PR

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 Update <small>_ August 2022</small>
 
-- test: verify changelog in PR (10/08/2022)
 - feat: add live flights command (08/08/2022)
 - feat: add events command (08/08/2022)
 - refactor: command cleanup (08/08/2022)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ August 2022</small>
 
+- test: verify changelog in PR (10/08/2022)
 - feat: add live flights command (08/08/2022)
 - feat: add events command (08/08/2022)
 - refactor: command cleanup (08/08/2022)

--- a/.github/workflows/verify-changelog.yml
+++ b/.github/workflows/verify-changelog.yml
@@ -1,0 +1,28 @@
+name: Verify Changelog
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Verify changelog
+        uses: Zomzog/changelog-checker@v1.2.0
+        with:
+          fileName: CHANGELOG.md
+          checkNotification: Simple
+          noChangelogLabel: skip changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

A simpler test and does not use PR commenting. Previous PR:
- #267 

Utilizes a label that would need to be created: `skip changelog` to bypass the check if a changelog is not required.

## Test Results

Failed Changelog Test (no changelog in PR)
![test 1](
https://cdn.discordapp.com/attachments/825674445342638120/1006657569286258699/unknown.png)

Action types re-runs check when labeled or unlabelled.
![test 2](https://cdn.discordapp.com/attachments/825674445342638120/1006657668267651092/unknown.png)

## Discord Username

Valastiri#8902
