### PR TITLE
feat: docsearch command to search documentation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Update <small>_ August 2022</small>
 
-- feat: add doc search command (10/08/2022)
+- feat: add docsearch command (10/08/2022)
 - ci: verify changelog in PR (10/08/2022)
 - feat: add live flights command (08/08/2022)
 - feat: add events command (08/08/2022)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ August 2022</small>
 
+- feat: add doc search command (10/08/2022)
 - ci: verify changelog in PR (10/08/2022)
 - feat: add live flights command (08/08/2022)
 - feat: add events command (08/08/2022)

--- a/.github/command-docs.md
+++ b/.github/command-docs.md
@@ -76,23 +76,23 @@
 
 ### General
 
-| Command      | Description                                                                                                    | Alias                      |
-|:-------------|:---------------------------------------------------------------------------------------------------------------|:---------------------------|
-| .docsearch   | Provides a link to the FlyByWire documentation, either a general link, or a link for a specific search         | .documentation <br/> .doc  |
-| .donate      | Provides a link to the open collective                                                                         | ---                        |
-| .goldenrules | Provides an image describing the golden rules an Airbus pilot should follow                                    | .golden <br/> .gr          |
-| .headwind    | Provides link to the Headwind Discord server                                                                   | .hw                        |
-| .installer   | Provides link to the new installer                                                                             | ---                        |
-| .latlong     | Provides a cheat sheet for conversion between Latitude and longitude coordinates between short and long format | .llfix                     |
-| .msfsdisc    | Provides link to Microsoft Flight Simulator discord server                                                     | .fsdisc <br/> .msfsdiscord |
-| .qa          | Links to the Quality Assurance docs page                                                                       | ---                        |
-| .roadmap     | FBW Roadmap                                                                                                    | .goals                     |
-| .salty       | Provides link to salty discord server                                                                          | .sal <br/> .ninjo          |
-| .synaptic    | Provides link to synaptic discord server                                                                       | .syn                       |
-| .translate   | Provides information on how to contribute to various FlyByWire translation efforts                             | ---                        |
-| .when        | Explain the absence of release dates or ETAs                                                                   | ---                        |
-| .thumb       | Answers the big question, will it have FEATURE?                                                                | .willithave                |
-| .xbox        | Short response + link to NOTAM for xbox marketplace                                                            | .xboxmarketplace           |
+| Command      | Description                                                                                                    | Alias                                 |
+|:-------------|:---------------------------------------------------------------------------------------------------------------|:--------------------------------------|
+| .docsearch   | Provides a link to the FlyByWire documentation, either a general link, or a link for a specific search         | .documentation <br/> .docs <br/> .doc |
+| .donate      | Provides a link to the open collective                                                                         | ---                                   |
+| .goldenrules | Provides an image describing the golden rules an Airbus pilot should follow                                    | .golden <br/> .gr                     |
+| .headwind    | Provides link to the Headwind Discord server                                                                   | .hw                                   |
+| .installer   | Provides link to the new installer                                                                             | ---                                   |
+| .latlong     | Provides a cheat sheet for conversion between Latitude and longitude coordinates between short and long format | .llfix                                |
+| .msfsdisc    | Provides link to Microsoft Flight Simulator discord server                                                     | .fsdisc <br/> .msfsdiscord            |
+| .qa          | Links to the Quality Assurance docs page                                                                       | ---                                   |
+| .roadmap     | FBW Roadmap                                                                                                    | .goals                                |
+| .salty       | Provides link to salty discord server                                                                          | .sal <br/> .ninjo                     |
+| .synaptic    | Provides link to synaptic discord server                                                                       | .syn                                  |
+| .translate   | Provides information on how to contribute to various FlyByWire translation efforts                             | ---                                   |
+| .when        | Explain the absence of release dates or ETAs                                                                   | ---                                   |
+| .thumb       | Answers the big question, will it have FEATURE?                                                                | .willithave                           |
+| .xbox        | Short response + link to NOTAM for xbox marketplace                                                            | .xboxmarketplace                      |
 
 ### Utilities
 

--- a/.github/command-docs.md
+++ b/.github/command-docs.md
@@ -76,23 +76,23 @@
 
 ### General
 
-| Command      | Description                                                                                                    | Alias                           |
-|:-------------|:---------------------------------------------------------------------------------------------------------------|:--------------------------------|
-| .doc         | Provides a link to the FlyByWire documentation, either a general link, or a link for a specific search         | .documentation <br/> .docsearch |
-| .donate      | Provides a link to the open collective                                                                         | ---                             |
-| .goldenrules | Provides an image describing the golden rules an Airbus pilot should follow                                    | .golden <br/> .gr               |
-| .headwind    | Provides link to the Headwind Discord server                                                                   | .hw                             |
-| .installer   | Provides link to the new installer                                                                             | ---                             |
-| .latlong     | Provides a cheat sheet for conversion between Latitude and longitude coordinates between short and long format | .llfix                          |
-| .msfsdisc    | Provides link to Microsoft Flight Simulator discord server                                                     | .fsdisc <br/> .msfsdiscord      |
-| .qa          | Links to the Quality Assurance docs page                                                                       | ---                             |
-| .roadmap     | FBW Roadmap                                                                                                    | .goals                          |
-| .salty       | Provides link to salty discord server                                                                          | .sal <br/> .ninjo               |
-| .synaptic    | Provides link to synaptic discord server                                                                       | .syn                            |
-| .translate   | Provides information on how to contribute to various FlyByWire translation efforts                             | ---                             |
-| .when        | Explain the absence of release dates or ETAs                                                                   | ---                             |
-| .thumb       | Answers the big question, will it have FEATURE?                                                                | .willithave                     |
-| .xbox        | Short response + link to NOTAM for xbox marketplace                                                            | .xboxmarketplace                |
+| Command      | Description                                                                                                    | Alias                      |
+|:-------------|:---------------------------------------------------------------------------------------------------------------|:---------------------------|
+| .docsearch   | Provides a link to the FlyByWire documentation, either a general link, or a link for a specific search         | .documentation <br/> .doc  |
+| .donate      | Provides a link to the open collective                                                                         | ---                        |
+| .goldenrules | Provides an image describing the golden rules an Airbus pilot should follow                                    | .golden <br/> .gr          |
+| .headwind    | Provides link to the Headwind Discord server                                                                   | .hw                        |
+| .installer   | Provides link to the new installer                                                                             | ---                        |
+| .latlong     | Provides a cheat sheet for conversion between Latitude and longitude coordinates between short and long format | .llfix                     |
+| .msfsdisc    | Provides link to Microsoft Flight Simulator discord server                                                     | .fsdisc <br/> .msfsdiscord |
+| .qa          | Links to the Quality Assurance docs page                                                                       | ---                        |
+| .roadmap     | FBW Roadmap                                                                                                    | .goals                     |
+| .salty       | Provides link to salty discord server                                                                          | .sal <br/> .ninjo          |
+| .synaptic    | Provides link to synaptic discord server                                                                       | .syn                       |
+| .translate   | Provides information on how to contribute to various FlyByWire translation efforts                             | ---                        |
+| .when        | Explain the absence of release dates or ETAs                                                                   | ---                        |
+| .thumb       | Answers the big question, will it have FEATURE?                                                                | .willithave                |
+| .xbox        | Short response + link to NOTAM for xbox marketplace                                                            | .xboxmarketplace           |
 
 ### Utilities
 

--- a/.github/command-docs.md
+++ b/.github/command-docs.md
@@ -76,22 +76,23 @@
 
 ### General
 
-| Command      | Description                                                                                                    | Alias                    |
-|:-------------|:---------------------------------------------------------------------------------------------------------------|:-------------------------|
-| .donate      | Provides a link to the open collective                                                                         | ---                      |
-| .goldenrules | Provides an image describing the golden rules an Airbus pilot should follow                                    | .golden <br> .gr         |
-| .headwind    | Provides link to the Headwind Discord server                                                                   | .hw                      |
-| .installer   | Provides link to the new installer                                                                             | ---                      |
-| .latlong     | Provides a cheat sheet for conversion between Latitude and longitude coordinates between short and long format | .llfix                   |
-| .msfsdisc    | Provides link to Microsoft Flight Simulator discord server                                                     | .fsdisc <br> .msfsdiscord|
-| .qa          | Links to the Quality Assurance docs page                                                                       | ---                      |
-| .roadmap     | FBW Roadmap                                                                                                    | .goals                   |
-| .salty       | Provides link to salty discord server                                                                          | .sal <br> .ninjo         |
-| .synaptic    | Provides link to synaptic discord server                                                                       | .syn                     |
-| .translate   | Provides information on how to contribute to various FlyByWire translation efforts                             | ---                      |
-| .when        | Explain the absence of release dates or ETAs                                                                   | ---                      |
-| .thumb       | Answers the big question, will it have FEATURE?                                                                | .willithave              |
-| .xbox        | Short response + link to NOTAM for xbox marketplace                                                            | .xboxmarketplace         |
+| Command      | Description                                                                                                    | Alias                           |
+|:-------------|:---------------------------------------------------------------------------------------------------------------|:--------------------------------|
+| .doc         | Provides a link to the FlyByWire documentation, either a general link, or a link for a specific search         | .documentation <br/> .docsearch |
+| .donate      | Provides a link to the open collective                                                                         | ---                             |
+| .goldenrules | Provides an image describing the golden rules an Airbus pilot should follow                                    | .golden <br/> .gr               |
+| .headwind    | Provides link to the Headwind Discord server                                                                   | .hw                             |
+| .installer   | Provides link to the new installer                                                                             | ---                             |
+| .latlong     | Provides a cheat sheet for conversion between Latitude and longitude coordinates between short and long format | .llfix                          |
+| .msfsdisc    | Provides link to Microsoft Flight Simulator discord server                                                     | .fsdisc <br/> .msfsdiscord      |
+| .qa          | Links to the Quality Assurance docs page                                                                       | ---                             |
+| .roadmap     | FBW Roadmap                                                                                                    | .goals                          |
+| .salty       | Provides link to salty discord server                                                                          | .sal <br/> .ninjo               |
+| .synaptic    | Provides link to synaptic discord server                                                                       | .syn                            |
+| .translate   | Provides information on how to contribute to various FlyByWire translation efforts                             | ---                             |
+| .when        | Explain the absence of release dates or ETAs                                                                   | ---                             |
+| .thumb       | Answers the big question, will it have FEATURE?                                                                | .willithave                     |
+| .xbox        | Short response + link to NOTAM for xbox marketplace                                                            | .xboxmarketplace                |
 
 ### Utilities
 

--- a/src/commands/general/doc.ts
+++ b/src/commands/general/doc.ts
@@ -1,0 +1,48 @@
+import Filter from 'bad-words';
+import { Colors } from 'discord.js';
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed } from '../../lib/embed';
+
+export const doc: CommandDefinition = {
+    name: ['doc', 'documentation', 'docsearch'],
+    description: 'Provides a link to the documentation or documentation search for a quick link if there is no dedicated command.',
+    category: CommandCategory.GENERAL,
+    executor: (msg) => {
+        const splitUp = msg.content.replace(/\.(doc|documentation|docsearch)\s+/, ' ').split(' ');
+
+        if (splitUp.length <= 1) {
+            const noQueryEmbed = makeEmbed({
+                title: 'FlyByWire Documentation',
+                description: 'Find the full FlyByWire Documentation [here.](https://docs.flybywiresim.com/)',
+            });
+            return msg.channel.send({ embeds: [noQueryEmbed] });
+        }
+
+        const searchText = splitUp[1];
+
+        // Safety to prevent users from sending their own links in bot output.
+        try {
+            const _ = new URL(searchText);
+            const URLEmbed = makeEmbed({
+                title: 'FlyByWire Documentation | Error',
+                description: 'Providing URLs to the Documentation search command is not allowed.',
+                color: Colors.Red,
+            });
+            return msg.channel.send({ embeds: [URLEmbed] });
+        } catch (_) { /**/ }
+
+        // Safety to prevent users from entering unexpected data that might result in strange behavior in a URL.
+        const encodedSearchText = encodeURIComponent(searchText);
+        const filter = new Filter();
+        if (filter.isProfane(searchText)) {
+            return msg.reply('Please do not use profane language with this command.');
+        }
+
+        const queryEmbed = makeEmbed({
+            title: 'FlyByWire Documentation Search',
+            description: `Find the FlyByWire Documentation for "${searchText}" [here.](https://docs.flybywiresim.com/?q=${encodedSearchText})`,
+        });
+        return msg.channel.send({ embeds: [queryEmbed] });
+    },
+};

--- a/src/commands/general/doc.ts
+++ b/src/commands/general/doc.ts
@@ -9,39 +9,45 @@ export const doc: CommandDefinition = {
     description: 'Provides a link to the documentation or documentation search for a quick link if there is no dedicated command.',
     category: CommandCategory.GENERAL,
     executor: (msg) => {
-        const splitUp = msg.content.replace(/\.(doc|documentation|docsearch)\s+/, ' ').split(' ');
+        const searchWords = msg.content.replace(/^\.(doc|documentation|docsearch)\s+/, ' ').split(' ');
 
-        if (splitUp.length <= 1) {
+        if (searchWords.length <= 1) {
             const noQueryEmbed = makeEmbed({
                 title: 'FlyByWire Documentation',
-                description: 'Find the full FlyByWire Documentation [here.](https://docs.flybywiresim.com/)',
+                description: 'Find the full FlyByWire Documentation [here](https://docs.flybywiresim.com/).',
             });
             return msg.channel.send({ embeds: [noQueryEmbed] });
         }
 
-        const searchText = splitUp[1];
-
+        console.log(searchWords);
         // Safety to prevent users from sending their own links in bot output.
-        try {
-            const _ = new URL(searchText);
-            const URLEmbed = makeEmbed({
-                title: 'FlyByWire Documentation | Error',
-                description: 'Providing URLs to the Documentation search command is not allowed.',
-                color: Colors.Red,
-            });
-            return msg.channel.send({ embeds: [URLEmbed] });
-        } catch (_) { /**/ }
+        for (const searchWord of searchWords) {
+            try {
+                const _ = new URL(searchWord);
+                const URLEmbed = makeEmbed({
+                    title: 'FlyByWire Documentation | Error',
+                    description: 'Providing URLs to the Documentation search command is not allowed.',
+                    color: Colors.Red,
+                });
+                return msg.channel.send({ embeds: [URLEmbed] });
+            } catch (_) { /**/ }
+
+            const filter = new Filter();
+            if (filter.isProfane(searchWord)) {
+                return msg.reply('Please do not use profane language with this command.');
+            }
+        }
+
+        // Removing first element as it is an empty string
+        searchWords.shift();
+        const searchQuery = searchWords.join(' ');
 
         // Safety to prevent users from entering unexpected data that might result in strange behavior in a URL.
-        const encodedSearchText = encodeURIComponent(searchText);
-        const filter = new Filter();
-        if (filter.isProfane(searchText)) {
-            return msg.reply('Please do not use profane language with this command.');
-        }
+        const encodedSearchQuery = encodeURIComponent(searchQuery);
 
         const queryEmbed = makeEmbed({
             title: 'FlyByWire Documentation Search',
-            description: `Find the FlyByWire Documentation for "${searchText}" [here.](https://docs.flybywiresim.com/?q=${encodedSearchText})`,
+            description: `Search the FlyByWire Documentation for "${searchQuery}" [here](https://docs.flybywiresim.com/?q=${encodedSearchQuery}).`,
         });
         return msg.channel.send({ embeds: [queryEmbed] });
     },

--- a/src/commands/general/docsearch.ts
+++ b/src/commands/general/docsearch.ts
@@ -4,8 +4,8 @@ import { CommandDefinition } from '../../lib/command';
 import { CommandCategory } from '../../constants';
 import { makeEmbed } from '../../lib/embed';
 
-export const doc: CommandDefinition = {
-    name: ['doc', 'documentation', 'docsearch'],
+export const docsearch: CommandDefinition = {
+    name: ['docsearch', 'documentation', 'doc'],
     description: 'Provides a link to the documentation or documentation search for a quick link if there is no dedicated command.',
     category: CommandCategory.GENERAL,
     executor: (msg) => {

--- a/src/commands/general/docsearch.ts
+++ b/src/commands/general/docsearch.ts
@@ -19,7 +19,6 @@ export const docsearch: CommandDefinition = {
             return msg.channel.send({ embeds: [noQueryEmbed] });
         }
 
-        console.log(searchWords);
         // Safety to prevent users from sending their own links in bot output.
         for (const searchWord of searchWords) {
             try {

--- a/src/commands/general/docsearch.ts
+++ b/src/commands/general/docsearch.ts
@@ -4,17 +4,19 @@ import { CommandDefinition } from '../../lib/command';
 import { CommandCategory } from '../../constants';
 import { makeEmbed } from '../../lib/embed';
 
+const DOCS_BASE_URL = 'https://docs.flybywiresim.com';
+
 export const docsearch: CommandDefinition = {
-    name: ['docsearch', 'documentation', 'doc'],
+    name: ['docsearch', 'documentation', 'doc', 'docs'],
     description: 'Provides a link to the documentation or documentation search for a quick link if there is no dedicated command.',
     category: CommandCategory.GENERAL,
     executor: (msg) => {
-        const searchWords = msg.content.replace(/^\.(doc|documentation|docsearch)\s+/, ' ').split(' ');
+        const searchWords = msg.content.replace(/^\.(doc|docs|documentation|docsearch)\s+/, ' ').split(' ');
 
         if (searchWords.length <= 1) {
             const noQueryEmbed = makeEmbed({
                 title: 'FlyByWire Documentation',
-                description: 'Find the full FlyByWire Documentation [here](https://docs.flybywiresim.com/).',
+                description: `Find the full FlyByWire Documentation [here](${DOCS_BASE_URL}).`,
             });
             return msg.channel.send({ embeds: [noQueryEmbed] });
         }
@@ -37,7 +39,6 @@ export const docsearch: CommandDefinition = {
             }
         }
 
-        // Removing first element as it is an empty string
         searchWords.shift();
         const searchQuery = searchWords.join(' ');
 
@@ -46,7 +47,7 @@ export const docsearch: CommandDefinition = {
 
         const queryEmbed = makeEmbed({
             title: 'FlyByWire Documentation Search',
-            description: `Search the FlyByWire Documentation for "${searchQuery}" [here](https://docs.flybywiresim.com/?q=${encodedSearchQuery}).`,
+            description: `Search the FlyByWire Documentation for "${searchQuery}" [here](${DOCS_BASE_URL}/?q=${encodedSearchQuery}).`,
         });
         return msg.channel.send({ embeds: [queryEmbed] });
     },

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -130,6 +130,7 @@ import { fma } from './a32nx/fma';
 import { noHello } from './memes/noHello';
 import { vatsimEvents } from './utils/vatsimEvents';
 import { flights } from './utils/flights';
+import { doc } from './general/doc';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -262,6 +263,7 @@ const commands: CommandDefinition[] = [
     noHello,
     vatsimEvents,
     flights,
+    doc,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -130,7 +130,7 @@ import { fma } from './a32nx/fma';
 import { noHello } from './memes/noHello';
 import { vatsimEvents } from './utils/vatsimEvents';
 import { flights } from './utils/flights';
-import { doc } from './general/doc';
+import { docsearch } from './general/docsearch';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -263,7 +263,7 @@ const commands: CommandDefinition[] = [
     noHello,
     vatsimEvents,
     flights,
-    doc,
+    docsearch,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};


### PR DESCRIPTION
feat: doc command to search documentation

## Description
This command has the following functionality:
* Listen to `.doc`, `.docsearch` and `.documentation`
* If no argument is given, it provides a link to the documentation website
* If an argument is given (one or more words), it provides a link to the documentation search functionality
* It checks for profanity
* It checks for URLs to minimize the risk of abusing the bot for pushing your own URL into a bot output
* It URI encodes the search to prevent injection of unwanted characters in the URL itself

## Test Results
Positive cases
<img width="497" alt="Screen Shot 2022-08-09 at 6 29 32 PM" src="https://user-images.githubusercontent.com/942391/183791216-3517fd8a-14b9-452b-8076-1d29ae74c4fe.png">

Negative cases
<img width="519" alt="Screen Shot 2022-08-09 at 6 29 44 PM" src="https://user-images.githubusercontent.com/942391/183791229-363b9399-5c10-46f4-b811-ff0f04cdec2e.png">

## Discord Username
straks#7240
