### PR TITLE
fix: temporaryCommandEdit - Improve permission validation and messaging

### DIFF
--- a/src/commands/moderation/temporaryCommandEdit.ts
+++ b/src/commands/moderation/temporaryCommandEdit.ts
@@ -190,7 +190,6 @@ const temporaryCommandEmbedField = (date: string, moderator: string, command: st
 
 export const temporarycommandedit: CommandDefinition = {
     name: ['temporarycommandedit', 'tempcommandedit', 'tcedit', 'tcmod'],
-    requiredPermissions: ['BanMembers'],
     description: 'Creates a temporary command for temporary use.',
     category: CommandCategory.MODERATION,
     executor: async (msg) => {


### PR DESCRIPTION
## fix: temporaryCommandEdit - Improve permission validation and messaging

## Description

Fixing the permission messaging and only requiring the specific roles (ADMIN or MODERATOR)

## Test Results
<Needs final test on test server>

## Discord Username
straks#7240
