### PR TITLE
feat: verticalguidance, verticalguidancesymbols and verticalspeedpriority commands

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ August 2022</small>
 
+- feat: verticalguidance, verticalguidancesymbols and verticalspeedpriority commands (27/08/2022)
 - feat: website command (22/08/2022)
 - feat: add vatsim command (21/08/2022)
 - refactor: remove async from MSFS command and message delete (21/08/2022)

--- a/.github/command-docs.md
+++ b/.github/command-docs.md
@@ -2,44 +2,47 @@
 
 ### A32NX
 
-| Command        | Description                                                                           | Alias                                                  |
-|:---------------|:--------------------------------------------------------------------------------------|:-------------------------------------------------------|
-| .adirs         | Display help with ADIRS alignment                                                     | ---                                                    |
-| .afloor        | Provides a link to the Alpha Floor Tool-Tip                                           | ---                                                    |
-| .airframe      | Provides a link to the updated Simbrief airframe                                      | ---                                                    |
-| .assistance    | Explains to the user why assistance options should be disabled                        | .assi <br> .as                                         |
-| .atc           | Provides a link to the cFMS special notes section.                                    | ---                                                    |
-| .audio         | Provides support information about A32NX audio configuration                          | ---                                                    |
-| .autopilot     | Provides a link to the autopilot/fly-by-wire page within docs                         | .ap                                                    |
-| .beginnerguide | Provides a link to the Beginner Guide                                                 | .bg                                                    |
-| .briefing      | Provides a link to the A320neo Pilot Briefing                                         | .flightdeck <br> .pfd                                  |
-| .cfms          | Provides information on the new cfms                                                  | ---                                                    |
-| .checklist     | Displays the checklist                                                                | ---                                                    |
-| .cpdlc         | Provide info and docs link for Hoppie ACARS                                           | .pdc <br> .hoppie <br> .acars                          |
-| .ctrle         | Displays help regarding CTRL+E engine start                                           | .ctrl+e <br> .ctrl-e <br> .enginestart                 |
-| .efb           | Inquire about the state of the EFB                                                    | ---                                                    |
-| .experimantal  | Explains the current state of the experimental build                                  | .exp                                                   |
-| .fixinfo       | Provide information about the fix info feature                                        | ---                                                    |
-| .flextemp      | Provides a link to the a32nx flex temp guide                                          | .flex                                                  |
-| .freetext      | Provides a link to the FlyByWire free text feature guide                              | .ft                                                    |
-| .fma           | Provides a link to the FMA docs guide                                                 | ---                                                    |
-| .github        | provides the link to the A32NX GitHub Repository                                      | .repo <br> .repository                                 |
-| .liveries      | Provides a link to the flightsim.to A32NX liveries page                               | .liv                                                   |
-| .preflight     | Provides a link to the a32nx preflight guide                                          | ---                                                    |
-| .printer       | Provides a link to the FlyByWire printer tutorial video                               | ---                                                    |
-| .remotemcdu    | Provides a link to the FlyByWire remote MCDU feature guide                            | .mcdu <br> .remote                                     |
-| .rs            | Provides a link to the recommended settings docs guide                                | ---                                                    |
-| .screens       | Display help with avionics                                                            | .screen                                                |
-| .import        | Shows how to use SimBrief integration                                                 | .integration <br> .integ <br> .simbrief                |
-| .sop           | Displays first page of SOP and provides PDF download                                  | ---                                                    |
-| .waypoint      | Provides a link to the a32nx data management guid                                     | .storedwaypoint <br> .datamanagement                   |
-| .takeoff       | Provides an explanation as to why there is no takeoff calculator for V-speeds or FLEX | .calculator <br> .perf                                 |
-| .takeoffissues | Provides help regarding engine issues on takeoff                                      | .toi <br> .engines <br> .eng                           |
-| .tcas          | Provides support information about A32NX AP/FD TCAS                                   | ---                                                    |
-| .tiller        | Provides a link to the tiller feature guide                                           | .steer <br> .steering <br> .til <br> .nws              |
-| .versions      | Explains the different A32NX versions                                                 | ---                                                    |
-| .weather       | Explains the current state of the weather and terrain radars in experimental          | .wx                                                    |
-| .weights       | Provides a link to the fuel and weights docs guide                                    | .fuel <br> .wb <br> .w/b <br> .w+b <br> .wnb <br> .w&b |
+| Command                  | Description                                                                                       | Alias                                                  |
+|:-------------------------|:--------------------------------------------------------------------------------------------------|:-------------------------------------------------------|
+| .adirs                   | Display help with ADIRS alignment                                                                 | ---                                                    |
+| .afloor                  | Provides a link to the Alpha Floor Tool-Tip                                                       | ---                                                    |
+| .airframe                | Provides a link to the updated Simbrief airframe                                                  | ---                                                    |
+| .assistance              | Explains to the user why assistance options should be disabled                                    | .assi <br> .as                                         |
+| .atc                     | Provides a link to the cFMS special notes section.                                                | ---                                                    |
+| .audio                   | Provides support information about A32NX audio configuration                                      | ---                                                    |
+| .autopilot               | Provides a link to the autopilot/fly-by-wire page within docs                                     | .ap                                                    |
+| .beginnerguide           | Provides a link to the Beginner Guide                                                             | .bg                                                    |
+| .briefing                | Provides a link to the A320neo Pilot Briefing                                                     | .flightdeck <br> .pfd                                  |
+| .cfms                    | Provides information on the new cfms                                                              | ---                                                    |
+| .checklist               | Displays the checklist                                                                            | ---                                                    |
+| .cpdlc                   | Provide info and docs link for Hoppie ACARS                                                       | .pdc <br> .hoppie <br> .acars                          |
+| .ctrle                   | Displays help regarding CTRL+E engine start                                                       | .ctrl+e <br> .ctrl-e <br> .enginestart                 |
+| .efb                     | Inquire about the state of the EFB                                                                | ---                                                    |
+| .experimantal            | Explains the current state of the experimental build                                              | .exp                                                   |
+| .fixinfo                 | Provide information about the fix info feature                                                    | ---                                                    |
+| .flextemp                | Provides a link to the a32nx flex temp guide                                                      | .flex                                                  |
+| .freetext                | Provides a link to the FlyByWire free text feature guide                                          | .ft                                                    |
+| .fma                     | Provides a link to the FMA docs guide                                                             | ---                                                    |
+| .github                  | provides the link to the A32NX GitHub Repository                                                  | .repo <br> .repository                                 |
+| .liveries                | Provides a link to the flightsim.to A32NX liveries page                                           | .liv                                                   |
+| .preflight               | Provides a link to the a32nx preflight guide                                                      | ---                                                    |
+| .printer                 | Provides a link to the FlyByWire printer tutorial video                                           | ---                                                    |
+| .remotemcdu              | Provides a link to the FlyByWire remote MCDU feature guide                                        | .mcdu <br> .remote                                     |
+| .rs                      | Provides a link to the recommended settings docs guide                                            | ---                                                    |
+| .screens                 | Display help with avionics                                                                        | .screen                                                |
+| .import                  | Shows how to use SimBrief integration                                                             | .integration <br> .integ <br> .simbrief                |
+| .sop                     | Displays first page of SOP and provides PDF download                                              | ---                                                    |
+| .waypoint                | Provides a link to the a32nx data management guid                                                 | .storedwaypoint <br> .datamanagement                   |
+| .takeoff                 | Provides an explanation as to why there is no takeoff calculator for V-speeds or FLEX             | .calculator <br> .perf                                 |
+| .takeoffissues           | Provides help regarding engine issues on takeoff                                                  | .toi <br> .engines <br> .eng                           |
+| .tcas                    | Provides support information about A32NX AP/FD TCAS                                               | ---                                                    |
+| .tiller                  | Provides a link to the tiller feature guide                                                       | .steer <br> .steering <br> .til <br> .nws              |
+| .versions                | Explains the different A32NX versions                                                             | ---                                                    |
+| .verticalguidance        | Provides a link to the Vertical Guidance documentation (also referred to as VNAV)                 | .vnavdoc <br> .vnav                                    |
+| .verticalguidancesymbols | Provides a link to the Vertical Guidance Navigation Display Symbols documentation                 | .vnavsymbols <br> .vnavnd                              |
+| .verticalspeedpriority   | Explains the priority of V/S and FPA over the speed guidance and provides a link for more details | .vspriority <br> .fpapriority <br> .vspeed             |
+| .weather                 | Explains the current state of the weather and terrain radars in experimental                      | .wx                                                    |
+| .weights                 | Provides a link to the fuel and weights docs guide                                                | .fuel <br> .wb <br> .w/b <br> .w+b <br> .wnb <br> .w&b |
 
 ### Support
 

--- a/src/commands/a32nx/verticalGuidance.ts
+++ b/src/commands/a32nx/verticalGuidance.ts
@@ -10,7 +10,7 @@ export const verticalGuidance: CommandDefinition = {
         const verticalGuidanceEmbed = makeEmbed({
             title: 'FlyByWire A32NX | Vertical Guidance Documentation',
             description: makeLines([
-                'Please see our [Vertical Guidance documentation](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/overview/) for information on the VNAV capabilities of the FlyByWire A32nx.',
+                'Please see our [Vertical Guidance documentation](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/overview/) for information on the VNAV capabilities of the FlyByWire A32NX.',
                 '',
                 'If you\'d like to immediately go to a specific chapter please use the list below:',
                 '- [Overview](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/overview/)',

--- a/src/commands/a32nx/verticalGuidance.ts
+++ b/src/commands/a32nx/verticalGuidance.ts
@@ -1,0 +1,28 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed, makeLines } from '../../lib/embed';
+
+export const verticalGuidance: CommandDefinition = {
+    name: ['verticalguidance', 'vnavdoc', 'vnav'],
+    description: 'Provides a link to the Vertical Guidance documentation',
+    category: CommandCategory.A32NX,
+    executor: (msg) => {
+        const verticalGuidanceEmbed = makeEmbed({
+            title: 'FlyByWire A32NX | Vertical Guidance Documentation',
+            description: makeLines([
+                'Please see our [Vertical Guidance documentation](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/overview/) for information on the VNAV capabilities of the FlyByWire A32nx.',
+                '',
+                'If you\'d like to immediately go to a specific chapter please use the list below:',
+                '- [Overview](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/overview/)',
+                '- [Selected Vertical Modes](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/selected-modes/)',
+                '- [Managed Vertical Modes](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/managed-modes/)',
+                '- [Speed/Mach Control](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/speed-control/)',
+                '- [Navigation Display Symbols](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/nd-symbols/)',
+                '- [Primary Flight Display Indications](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/pfd-indications/)',
+                '- [Example Managed Flight](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/example/)',
+            ]),
+        });
+
+        return msg.channel.send({ embeds: [verticalGuidanceEmbed] });
+    },
+};

--- a/src/commands/a32nx/verticalGuidanceSymbols.ts
+++ b/src/commands/a32nx/verticalGuidanceSymbols.ts
@@ -1,0 +1,17 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed } from '../../lib/embed';
+
+export const verticalGuidanceSymbols: CommandDefinition = {
+    name: ['verticalguidancesymbols', 'vnavsymbols', 'vnavnd'],
+    description: 'Provides a link to the Vertical Guidance ND Symbols',
+    category: CommandCategory.A32NX,
+    executor: (msg) => {
+        const verticalGuidanceSymbolsEmbed = makeEmbed({
+            title: 'FlyByWire A32NX | Vertical Guidance Navigation Display Symbols documentation',
+            description: 'Please see our [Vertical Guidance Navigation Display Symbols documentation](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/nd-symbols/) for information on the VNAV symbols on the ND of the FlyByWire A32nx.',
+        });
+
+        return msg.channel.send({ embeds: [verticalGuidanceSymbolsEmbed] });
+    },
+};

--- a/src/commands/a32nx/verticalGuidanceSymbols.ts
+++ b/src/commands/a32nx/verticalGuidanceSymbols.ts
@@ -9,7 +9,7 @@ export const verticalGuidanceSymbols: CommandDefinition = {
     executor: (msg) => {
         const verticalGuidanceSymbolsEmbed = makeEmbed({
             title: 'FlyByWire A32NX | Vertical Guidance Navigation Display Symbols documentation',
-            description: 'Please see our [Vertical Guidance Navigation Display Symbols documentation](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/nd-symbols/) for information on the VNAV symbols on the ND of the FlyByWire A32nx.',
+            description: 'Please see our [Vertical Guidance Navigation Display Symbols documentation](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/nd-symbols/) for information on the VNAV symbols on the ND of the FlyByWire A32NX.',
         });
 
         return msg.channel.send({ embeds: [verticalGuidanceSymbolsEmbed] });

--- a/src/commands/a32nx/verticalSpeedPriority.ts
+++ b/src/commands/a32nx/verticalSpeedPriority.ts
@@ -1,0 +1,23 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed, makeLines } from '../../lib/embed';
+
+export const verticalSpeedPriority: CommandDefinition = {
+    name: ['verticalspeedpriority', 'vspriority', 'fpapriority', 'vspeed'],
+    description: 'Explain the priority of Vertical Speed or Flight Path Angle over Speed guidance.',
+    category: CommandCategory.A32NX,
+    executor: (msg) => {
+        const verticalSpeedPriorityEmbed = makeEmbed({
+            title: 'FlyByWire A32NX | V/S & FPA Priority',
+            description: makeLines([
+                'The V/S (FPA) guidance has priority over the speed guidance. If the selected target V/S or FPA is too high (relative to the current thrust condition and speed), the FMGC will steer the aircraft to the target V/S or FPA, but the aircraft will also accelerate or decelerate.',
+                '',
+                'When the speed reaches its authorized limit, V/S or FPA automatically decreases to maintain the minimum or maximum speed limit.',
+                '',
+                'Please check the [Vertical Speed and Flight Path Angle documentation](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/selected-modes/#vs-and-fpa-vertical-speed-and-flight-path-angle) for more details.',
+            ]),
+        });
+
+        return msg.channel.send({ embeds: [verticalSpeedPriorityEmbed] });
+    },
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -138,6 +138,9 @@ import { yourControls } from './general/yourControls';
 import { notams } from './general/notams';
 import { vatsimData } from './utils/vatsimData';
 import { website } from './general/website';
+import { verticalGuidance } from './a32nx/verticalGuidance';
+import { verticalGuidanceSymbols } from './a32nx/verticalGuidanceSymbols';
+import { verticalSpeedPriority } from './a32nx/verticalSpeedPriority';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -278,6 +281,9 @@ const commands: CommandDefinition[] = [
     notams,
     vatsimData,
     website,
+    verticalGuidance,
+    verticalGuidanceSymbols,
+    verticalSpeedPriority,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};


### PR DESCRIPTION
## feat: verticalguidance, verticalguidancesymbols and verticalspeedpriority commands

## Description

Provides 3 new commands:
* verticalguidance, vnavdoc, vnav: Provides links to the Vertical
  Guidance documentation.
* verticalguidancesymbols, vnavsymbols, vnavnd: Provides a link to the
  Vertical Guidance Navigation Display Symbols documentation.
* verticalspeedpriority, vspriority, fpapriority, vspeed: Explains the
  priority of V/S and FPA over speed guidance and provides a link for
  more details.

## Test Results

<img width="598" alt="Screen Shot 2022-08-27 at 12 03 03 PM" src="https://user-images.githubusercontent.com/942391/187044692-256da5de-5fb4-41b0-9258-ec21c8628eed.png">

## Discord Username

straks#7240
