### PR TITLE
feat: flypados command for flyPadOS3 documentation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ August 2022</small>
 
+- feat: flypados command (27/08/2022)
 - feat: website command (22/08/2022)
 - feat: add vatsim command (21/08/2022)
 - refactor: remove async from MSFS command and message delete (21/08/2022)

--- a/.github/command-docs.md
+++ b/.github/command-docs.md
@@ -21,6 +21,7 @@
 | .experimantal  | Explains the current state of the experimental build                                  | .exp                                                   |
 | .fixinfo       | Provide information about the fix info feature                                        | ---                                                    |
 | .flextemp      | Provides a link to the a32nx flex temp guide                                          | .flex                                                  |
+| .flypados      | Provides a link to the flyPadOS3 documentation                                        | .flypad <br> .efbos                                    |
 | .freetext      | Provides a link to the FlyByWire free text feature guide                              | .ft                                                    |
 | .fma           | Provides a link to the FMA docs guide                                                 | ---                                                    |
 | .github        | provides the link to the A32NX GitHub Repository                                      | .repo <br> .repository                                 |

--- a/src/commands/a32nx/flyPadOS.ts
+++ b/src/commands/a32nx/flyPadOS.ts
@@ -4,11 +4,11 @@ import { makeEmbed, makeLines } from '../../lib/embed';
 
 export const flyPadOS: CommandDefinition = {
     name: ['flypados', 'flypad', 'efbos'],
-    description: 'Provides a link to the FlightPadOS documentation',
+    description: 'Provides a link to the FlyPadOS documentation',
     category: CommandCategory.A32NX,
     executor: (msg) => {
         const flyPadOSEmbed = makeEmbed({
-            title: 'FlyByWire A32NX | FlightPadOS Documentation',
+            title: 'FlyByWire A32NX | FlyPadOS Documentation',
             description: makeLines([
                 'Please see our [flyPadOS3 Documentation](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/) for information on how to set up and use the Electronic Flight Bag with flyPadOS3.',
                 '',
@@ -26,7 +26,7 @@ export const flyPadOS: CommandDefinition = {
                 '- [Settings](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/settings/)',
                 '- [Throttle Calibration](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/throttle-calibration/)',
                 '',
-                'See the [flyPadOS2 documentation](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados2/) for the older version of the EFB flyPadOS.',
+                'See the [flyPadOS2 documentation](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados2/) for the older version of flyPadOS.',
             ]),
         });
 

--- a/src/commands/a32nx/flyPadOS.ts
+++ b/src/commands/a32nx/flyPadOS.ts
@@ -1,0 +1,35 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed, makeLines } from '../../lib/embed';
+
+export const flyPadOS: CommandDefinition = {
+    name: ['flypados', 'flypad', 'efbos'],
+    description: 'Provides a link to the FlightPadOS documentation',
+    category: CommandCategory.A32NX,
+    executor: (msg) => {
+        const flyPadOSEmbed = makeEmbed({
+            title: 'FlyByWire A32NX | FlightPadOS Documentation',
+            description: makeLines([
+                'Please see our [flyPadOS3 Documentation](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/) for information on how to set up and use the Electronic Flight Bag with flyPadOS3.',
+                '',
+                'If you\'d like to immediately go to a specific chapter please use the list below:',
+                '- [Overview](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/)',
+                '- [Dashboard](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/dashboard/)',
+                '- [Dispatch](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/dispatch/)',
+                '- [Ground](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/ground/)',
+                '- [Performance](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/performance/)',
+                '- [Navigation & Charts](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/charts/)',
+                '- [Online ATC](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/online-atc/)',
+                '- [Failures](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/failures/)',
+                '- [Interactive Checklists](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/checklists/)',
+                '- [Interior Lighting and Aircraft Presets](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/presets/)',
+                '- [Settings](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/settings/)',
+                '- [Throttle Calibration](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/throttle-calibration/)',
+                '',
+                'See the [flyPadOS2 documentation](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados2/) for the older version of the EFB flyPadOS.',
+            ]),
+        });
+
+        return msg.channel.send({ embeds: [flyPadOSEmbed] });
+    },
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -138,6 +138,7 @@ import { yourControls } from './general/yourControls';
 import { notams } from './general/notams';
 import { vatsimData } from './utils/vatsimData';
 import { website } from './general/website';
+import { flyPadOS } from './a32nx/flyPadOS';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -278,6 +279,7 @@ const commands: CommandDefinition[] = [
     notams,
     vatsimData,
     website,
+    flyPadOS,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};


### PR DESCRIPTION
## feat: flypados command for flyPadOS3 documentation

## Description

Provides a command that will return links to the flyPadOS3 documentation
per chapter, and includes a link for the older flyPadOS2 documentation.

## Test Results

<img width="588" alt="Screen Shot 2022-08-27 at 12 28 17 PM" src="https://user-images.githubusercontent.com/942391/187045342-e1e5c8e8-ec0e-4059-bdc9-1df33e706c61.png">

## Discord Username

straks#7240