### PR TITLE
feat: expand vatsim stats with search and separate observers in its own category

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ August 2022</small>
 
+- feat: expand vatsim stats with search and separate observers in its own category (28/08/2022)
 - feat: verticalguidance, verticalguidancesymbols and verticalspeedpriority commands (27/08/2022)
 - feat: flypados command (27/08/2022)
 - feat: website command (22/08/2022)

--- a/src/commands/utils/vatsimData.ts
+++ b/src/commands/utils/vatsimData.ts
@@ -18,22 +18,27 @@ const helpEmbed = (evokedCommand: string) => makeEmbed({
         },
         {
             name: `Default usage: \`${evokedCommand} <callsign query>\``,
-            value: 'Returns information for online Controllers, Observers and ATIS matching the callsign query; or online Pilots with matching callsigns if no Controllers, Observers or ATIS were found.',
+            value: 'Returns information for online Controllers and ATIS matching the callsign query; or online Pilots with matching callsigns if no Controllers or ATIS were found; or online Observers if no Pilots were found.',
             inline: false,
         },
         {
             name: `Statistics: \`${evokedCommand} stats [callsign query]\``,
-            value: 'Returns statics about the number of online Pilots, Controllers and ATIS. If the optional callsign query is provided, it will only return statistics for callsigns matching the query.',
+            value: 'Returns statics about the number of online Pilots, Controllers, ATIS and Observers. If the optional callsign query is provided, it will only return statistics for callsigns matching the query.',
             inline: false,
         },
         {
             name: `Search online Controllers and ATIS: \`${evokedCommand} controllers <callsign query>\``,
-            value: 'Returns information for Controllers, Observers and ATIS matching the callsign query.',
+            value: 'Returns information for Controllers and ATIS matching the callsign query.',
             inline: false,
         },
         {
             name: `Search online Pilots: \`${evokedCommand} pilots <callsign query>\``,
             value: 'Returns information for Pilots matching the callsign query.',
+            inline: false,
+        },
+        {
+            name: `Search online Observers: \`${evokedCommand} observers <callsign query>\``,
+            value: 'Returns information for Observers matching the callsign query.',
             inline: false,
         },
     ],
@@ -45,9 +50,9 @@ const listEmbed = (type: string, fields: EmbedField[], totalCount: number, shown
     fields,
 });
 
-const statsEmbed = (pilots: string, controllers: string, atis: string, callsign: string) => makeEmbed({
+const statsEmbed = (pilots: string, controllers: string, atis: string, observers: string, callsign: string) => makeEmbed({
     title: callsign ? `VATSIM Data | Statistics for callsign ${callsign}` : 'VATSIM Data | Statistics',
-    description: callsign ? `An overview of the current active Pilots, Controllers and ATIS matching ${callsign}.` : 'An overview of the current active Pilots, Controllers and ATIS.',
+    description: callsign ? `An overview of the current active Pilots, Controllers, ATIS and Observers matching ${callsign}.` : 'An overview of the current active Pilots, Controllers, ATIS and Observers.',
     fields: [
         {
             name: 'Pilots',
@@ -62,6 +67,11 @@ const statsEmbed = (pilots: string, controllers: string, atis: string, callsign:
         {
             name: 'ATIS',
             value: atis,
+            inline: true,
+        },
+        {
+            name: 'Observers',
+            value: observers,
             inline: true,
         },
     ],
@@ -158,6 +168,36 @@ const pilotsListEmbedFields = (callsign: string, rating: string, flightPlan: any
     return fields;
 };
 
+const observersListEmbedFields = (callsign: string, logon: string, rating: string, atis: string): EmbedField[] => {
+    const fields = [
+        {
+            name: 'Callsign',
+            value: `${callsign}`,
+            inline: false,
+        },
+        {
+            name: 'Logon Date & Time',
+            value: `${logon}`,
+            inline: true,
+        },
+        {
+            name: 'Rating',
+            value: `${rating}`,
+            inline: true,
+        },
+    ];
+    if (atis !== null) {
+        const atisTitle = 'Info';
+        fields.push({
+            name: atisTitle,
+            value: atis,
+            inline: false,
+        });
+    }
+
+    return fields;
+};
+
 const handleLocaleDateTimeString = (date: Date) => date.toLocaleDateString('en-US', {
     hour: 'numeric',
     minute: 'numeric',
@@ -181,13 +221,13 @@ export const vatsimData: CommandDefinition = {
         let subCommand = args[0].toLowerCase();
         let [query] = args.slice(1);
 
-        if (subCommand !== 'stats' && subCommand !== 'controllers' && subCommand !== 'pilots') {
+        if (subCommand !== 'stats' && subCommand !== 'controllers' && subCommand !== 'pilots' && subCommand !== 'observers') {
             subCommand = 'all';
             [query] = args;
         }
 
         let commandMode = 'ALL';
-        let notFoundMsg = 'No online VATSIM Controllers, Observers, ATIS or Pilots found matching your callsign search query.';
+        let notFoundMsg = 'No online VATSIM Controllers, ATIS, Pilots or Observers found matching your callsign search query.';
 
         switch (subCommand) {
         case 'stats':
@@ -195,11 +235,15 @@ export const vatsimData: CommandDefinition = {
             break;
         case 'controllers':
             commandMode = 'CONTROLLERS';
-            notFoundMsg = 'No online VATSIM Controllers, Observers or ATIS found matching your callsign search query.';
+            notFoundMsg = 'No online VATSIM Controllers or ATIS found matching your callsign search query.';
             break;
         case 'pilots':
             commandMode = 'PILOTS';
             notFoundMsg = 'No online VATSIM Pilots found matching your callsign search query.';
+            break;
+        case 'observers':
+            commandMode = 'OBSERVERS';
+            notFoundMsg = 'No online VATSIM Observers found matching your callsign search query.';
             break;
         default:
             break;
@@ -217,11 +261,15 @@ export const vatsimData: CommandDefinition = {
             return msg.channel.send({ embeds: [fetchErrorEmbed(error)] });
         }
 
+        const vatsimAllControllers = vatsimData.controllers ? vatsimData.controllers.filter((controller) => controller.facility > 0) : null;
+        const vatsimAllObservers = vatsimData.controllers ? vatsimData.controllers.filter((controller) => controller.facility <= 0) : null;
+
         if (commandMode === 'STATS' && !query) {
             const vatsimPilotCount = vatsimData.pilots ? vatsimData.pilots.length : 0;
-            const vatsimControllerCount = vatsimData.controllers ? vatsimData.controllers.length : 0;
+            const vatsimControllerCount = vatsimAllControllers ? vatsimAllControllers.length : 0;
             const vatsimAtisCount = vatsimData.atis ? vatsimData.atis.length : 0;
-            return msg.channel.send({ embeds: [statsEmbed(vatsimPilotCount, vatsimControllerCount, vatsimAtisCount, null)] });
+            const vatsimObserverCount = vatsimAllObservers ? vatsimAllObservers.length : 0;
+            return msg.channel.send({ embeds: [statsEmbed(vatsimPilotCount, vatsimControllerCount, vatsimAtisCount, vatsimObserverCount, null)] });
         }
 
         if (!query) {
@@ -242,8 +290,9 @@ export const vatsimData: CommandDefinition = {
         const vatsimPilotRatings = vatsimData.pilot_ratings ? vatsimData.pilot_ratings : null;
         const vatsimControllerRatings = vatsimData.ratings ? vatsimData.ratings : null;
         const vatsimPilots = vatsimData.pilots ? vatsimData.pilots.filter((pilot) => pilot.callsign.includes(callsignSearch)) : null;
-        const vatsimControllers = vatsimData.controllers ? vatsimData.controllers.filter((controller) => controller.callsign.includes(callsignSearch)) : null;
+        const vatsimControllers = vatsimAllControllers ? vatsimAllControllers.filter((controller) => controller.callsign.includes(callsignSearch)) : null;
         const vatsimAtis = vatsimData.atis ? vatsimData.atis.filter((atis) => atis.callsign.includes(callsignSearch)) : null;
+        const vatsimObservers = vatsimAllObservers ? vatsimAllObservers.filter((observer) => observer.callsign.includes(callsignSearch)) : null;
 
         const { keys }: ObjectConstructor = Object;
 
@@ -251,7 +300,8 @@ export const vatsimData: CommandDefinition = {
             const vatsimPilotCount = vatsimPilots ? vatsimPilots.length : 0;
             const vatsimControllerCount = vatsimControllers ? vatsimControllers.length : 0;
             const vatsimAtisCount = vatsimAtis ? vatsimAtis.length : 0;
-            return msg.channel.send({ embeds: [statsEmbed(vatsimPilotCount, vatsimControllerCount, vatsimAtisCount, callsignSearch)] });
+            const vatsimObserverCount = vatsimObservers ? vatsimObservers.length : 0;
+            return msg.channel.send({ embeds: [statsEmbed(vatsimPilotCount, vatsimControllerCount, vatsimAtisCount, vatsimObserverCount, callsignSearch)] });
         }
 
         if ((keys(vatsimControllers).length !== 0 || keys(vatsimAtis).length !== 0) && (commandMode === 'ALL' || commandMode === 'CONTROLLERS')) {
@@ -271,7 +321,7 @@ export const vatsimData: CommandDefinition = {
             const totalCount = keys(vatsimControllers).length + keys(vatsimAtis).length;
             const shownCount = totalCount < 5 ? totalCount : 5;
 
-            return msg.channel.send({ embeds: [listEmbed('Controllers, Observers & ATIS', fields, totalCount, shownCount, callsignSearch)] });
+            return msg.channel.send({ embeds: [listEmbed('Controllers & ATIS', fields, totalCount, shownCount, callsignSearch)] });
         }
 
         if (keys(vatsimPilots).length !== 0 && (commandMode === 'ALL' || commandMode === 'PILOTS')) {
@@ -288,6 +338,25 @@ export const vatsimData: CommandDefinition = {
             const shownCount = totalCount < 5 ? totalCount : 5;
 
             return msg.channel.send({ embeds: [listEmbed('Pilots', fields, totalCount, shownCount, callsignSearch)] });
+        }
+
+        if (keys(vatsimObservers).length !== 0 && (commandMode === 'ALL' || commandMode === 'OBSERVERS')) {
+            const fields: EmbedField[] = [...vatsimObservers.sort((a, b) => b.rating - a.rating)].map((vatsimObserver) => {
+                const { callsign, logon_time, text_atis, rating } = vatsimObserver;
+                const logonTime = new Date(logon_time);
+                const logonTimeString = handleLocaleDateTimeString(logonTime);
+                const ratingDetail = vatsimControllerRatings.filter((ratingInfo) => ratingInfo.id === rating);
+                const { short, long } = ratingDetail[0];
+                const ratingText = `${short} - ${long}`;
+                const atisText = text_atis ? text_atis.join('\n') : null;
+
+                return observersListEmbedFields(callsign, logonTimeString, ratingText, atisText);
+            }).slice(0, 5).flat();
+
+            const totalCount = keys(vatsimObservers).length;
+            const shownCount = totalCount < 5 ? totalCount : 5;
+
+            return msg.channel.send({ embeds: [listEmbed('Observers', fields, totalCount, shownCount, callsignSearch)] });
         }
 
         return msg.channel.send({ embeds: [notFoundEmbed(callsignSearch, notFoundMsg)] });

--- a/src/commands/utils/vatsimData.ts
+++ b/src/commands/utils/vatsimData.ts
@@ -22,8 +22,8 @@ const helpEmbed = (evokedCommand: string) => makeEmbed({
             inline: false,
         },
         {
-            name: `Statistics: \`${evokedCommand} stats\``,
-            value: 'Returns statics about the number of online Pilots, Controllers and ATIS',
+            name: `Statistics: \`${evokedCommand} stats [callsign query]\``,
+            value: 'Returns statics about the number of online Pilots, Controllers and ATIS. If the optional callsign query is provided, it will only return statistics for callsigns matching the query.',
             inline: false,
         },
         {
@@ -45,9 +45,9 @@ const listEmbed = (type: string, fields: EmbedField[], totalCount: number, shown
     fields,
 });
 
-const statsEmbed = (pilots: string, controllers: string, atis: string) => makeEmbed({
-    title: 'VATSIM Data | Statistics',
-    description: 'An overview of the current active Pilots, Controllers and ATIS.',
+const statsEmbed = (pilots: string, controllers: string, atis: string, callsign: string) => makeEmbed({
+    title: callsign ? `VATSIM Data | Statistics for callsign ${callsign}` : 'VATSIM Data | Statistics',
+    description: callsign ? `An overview of the current active Pilots, Controllers and ATIS matching ${callsign}.` : 'An overview of the current active Pilots, Controllers and ATIS.',
     fields: [
         {
             name: 'Pilots',
@@ -217,11 +217,11 @@ export const vatsimData: CommandDefinition = {
             return msg.channel.send({ embeds: [fetchErrorEmbed(error)] });
         }
 
-        if (commandMode === 'STATS') {
+        if (commandMode === 'STATS' && !query) {
             const vatsimPilotCount = vatsimData.pilots ? vatsimData.pilots.length : 0;
             const vatsimControllerCount = vatsimData.controllers ? vatsimData.controllers.length : 0;
             const vatsimAtisCount = vatsimData.atis ? vatsimData.atis.length : 0;
-            return msg.channel.send({ embeds: [statsEmbed(vatsimPilotCount, vatsimControllerCount, vatsimAtisCount)] });
+            return msg.channel.send({ embeds: [statsEmbed(vatsimPilotCount, vatsimControllerCount, vatsimAtisCount, null)] });
         }
 
         if (!query) {
@@ -246,6 +246,13 @@ export const vatsimData: CommandDefinition = {
         const vatsimAtis = vatsimData.atis ? vatsimData.atis.filter((atis) => atis.callsign.includes(callsignSearch)) : null;
 
         const { keys }: ObjectConstructor = Object;
+
+        if (commandMode === 'STATS') {
+            const vatsimPilotCount = vatsimPilots ? vatsimPilots.length : 0;
+            const vatsimControllerCount = vatsimControllers ? vatsimControllers.length : 0;
+            const vatsimAtisCount = vatsimAtis ? vatsimAtis.length : 0;
+            return msg.channel.send({ embeds: [statsEmbed(vatsimPilotCount, vatsimControllerCount, vatsimAtisCount, callsignSearch)] });
+        }
 
         if ((keys(vatsimControllers).length !== 0 || keys(vatsimAtis).length !== 0) && (commandMode === 'ALL' || commandMode === 'CONTROLLERS')) {
             const fields: EmbedField[] = [...vatsimControllers.sort((a, b) => b.facility - a.facility), ...vatsimAtis]

--- a/src/commands/utils/vatsimData.ts
+++ b/src/commands/utils/vatsimData.ts
@@ -109,7 +109,12 @@ const controllersListEmbedFields = (callsign: string, frequency: string, logon: 
         },
     ];
     if (atis !== null) {
-        const atisTitle = atisCode ? `ATIS - Code: ${atisCode}` : 'ATIS';
+        let atisTitle = 'Info';
+        if (atisCode) {
+            atisTitle = `ATIS - Code: ${atisCode}`;
+        } else if (atisCode !== undefined) {
+            atisTitle = 'ATIS';
+        }
         fields.push({
             name: atisTitle,
             value: atis,


### PR DESCRIPTION
## feat: expand vatsim stats with search and separate observers in its own category

## Description

* Changing ATIS to Info for non-ATIS Controllers
* Introduce support for stats filtering/search
* Extract Observers from controllers
** Make Observers a separate command and group to search for instead of it being part of the Controllers. 
** Priority of search is Controlers & ATIS, then Pilots and finally Oberservers.
** Stats command is also expanded with observers information.

## Test Results

### Changing ATIS to Info for non-ATIS Controllers

<img width="555" alt="Screen Shot 2022-08-27 at 10 15 54 PM" src="https://user-images.githubusercontent.com/942391/187060831-127fec73-1963-44d9-9faf-128ac2a32965.png">

### Introduce support for stats filtering/search

<img width="538" alt="Screen Shot 2022-08-27 at 10 23 09 PM" src="https://user-images.githubusercontent.com/942391/187060832-16a6614e-0c0b-4f43-950d-4e2de3246d5c.png">
<img width="591" alt="Screen Shot 2022-08-27 at 10 23 55 PM" src="https://user-images.githubusercontent.com/942391/187060833-a8b2f39e-722f-4234-bb6d-8b3a64930578.png">
<img width="456" alt="Screen Shot 2022-08-27 at 10 52 16 PM" src="https://user-images.githubusercontent.com/942391/187060834-39c84400-9749-4a51-b9d8-4887a46c6ddd.png">

### Extract Observers from controllers

<img width="542" alt="Screen Shot 2022-08-27 at 10 56 22 PM" src="https://user-images.githubusercontent.com/942391/187060835-f512bed3-ff50-45b0-a647-0ad0ccfe9c91.png">
<img width="567" alt="Screen Shot 2022-08-27 at 10 56 56 PM" src="https://user-images.githubusercontent.com/942391/187060836-78753fed-7817-43a7-8606-b5a251c1fa12.png">
<img width="543" alt="Screen Shot 2022-08-27 at 11 00 28 PM" src="https://user-images.githubusercontent.com/942391/187060837-e4df9f92-389b-47d6-93b6-dd7e5ef2657c.png">
<img width="585" alt="Screen Shot 2022-08-27 at 11 04 17 PM" src="https://user-images.githubusercontent.com/942391/187060839-69552313-7f3f-48c0-816e-a4c9a3cf79d9.png">
<img width="583" alt="Screen Shot 2022-08-27 at 11 05 17 PM" src="https://user-images.githubusercontent.com/942391/187060841-eb041009-a154-49f3-be3a-7fce9a435876.png">
<img width="589" alt="Screen Shot 2022-08-27 at 11 06 01 PM" src="https://user-images.githubusercontent.com/942391/187060842-e8699d21-ca4b-46b3-af67-e2c4d434c95d.png">

## Discord Username

straks#7240
