### PR TITLE
feat: mcdu command for the detailed MCDU documentation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Update <small>_ September 2022</small>
 
+- feat: mcdu command for the detailed MCDU documentation (21/09/2022)
+- refactor: mcdu alias removed from remotemcdu command (21/09/2022)
 - fix: Changed image for assistance command (19/09/2022)
 - feat: add .dfd command (19/09/2022)
 - feat: executor added to the msgDelete log (07/09/2022)

--- a/.github/command-docs.md
+++ b/.github/command-docs.md
@@ -26,9 +26,10 @@
 | .fma                     | Provides a link to the FMA docs guide                                                             | ---                                                    |
 | .github                  | provides the link to the A32NX GitHub Repository                                                  | .repo <br> .repository                                 |
 | .liveries                | Provides a link to the flightsim.to A32NX liveries page                                           | .liv                                                   |
+| .mcdu                    | Provides a set of links to the detailed MCDU documentation                                        | .mcdudoc                                               |
 | .preflight               | Provides a link to the a32nx preflight guide                                                      | ---                                                    |
 | .printer                 | Provides a link to the FlyByWire printer tutorial video                                           | ---                                                    |
-| .remotemcdu              | Provides a link to the FlyByWire remote MCDU feature guide                                        | .mcdu <br> .remote                                     |
+| .remotemcdu              | Provides a link to the FlyByWire remote MCDU feature guide                                        | .remote                                                |
 | .rs                      | Provides a link to the recommended settings docs guide                                            | ---                                                    |
 | .screens                 | Display help with avionics                                                                        | .screen                                                |
 | .import                  | Shows how to use SimBrief integration                                                             | .integration <br> .integ <br> .simbrief                |

--- a/.github/command-docs.md
+++ b/.github/command-docs.md
@@ -29,7 +29,7 @@
 | .mcdu                    | Provides a set of links to the detailed MCDU documentation                                        | .mcdudoc                                               |
 | .preflight               | Provides a link to the a32nx preflight guide                                                      | ---                                                    |
 | .printer                 | Provides a link to the FlyByWire printer tutorial video                                           | ---                                                    |
-| .remotemcdu              | Provides a link to the FlyByWire remote MCDU feature guide                                        | .remote                                                |
+| .remotemcdu              | Provides a link to the FlyByWire remote MCDU feature guide                                        | ---                                                    |
 | .rs                      | Provides a link to the recommended settings docs guide                                            | ---                                                    |
 | .screens                 | Display help with avionics                                                                        | .screen                                                |
 | .import                  | Shows how to use SimBrief integration                                                             | .integration <br> .integ <br> .simbrief                |

--- a/src/commands/a32nx/mcdu.ts
+++ b/src/commands/a32nx/mcdu.ts
@@ -1,0 +1,35 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed, makeLines } from '../../lib/embed';
+
+export const mcdu: CommandDefinition = {
+    name: ['mcdu', 'mcdudoc'],
+    description: 'Provides a link to the MCDU documentation',
+    category: CommandCategory.A32NX,
+    executor: (msg) => {
+        const mcduEmbed = makeEmbed({
+            title: 'FlyByWire A32NX | MCDU Documentation',
+            description: makeLines([
+                'Please see our [MCDU documentation](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/) for information on the MCDU of the FlyByWire A32NX.',
+                '',
+                'If you\'d like to immediately go to a specific chapter please use the list below:',
+                '- [Overview](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/)',
+                '- [MCDU Interface](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/interface/)',
+                '- [DIR TO page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/dir/)',
+                '- [PROG page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/prog/)',
+                '- [PERF page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/perf/)',
+                '- [INIT page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/init/)',
+                '- [DATA page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/data/)',
+                '- [F-PLN page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/f-pln/)',
+                '- [RAD NAV page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/rad-nav/)',
+                '- [FUEL PRED page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/fuel-pred/)',
+                '- [SEC F-PLN page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/sec-f-plan/)',
+                '- [ATC COMM page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/atc-comm/)',
+                '- [MCDU MENU page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/mcdu-menu/)',
+                '- [MCDU Messages](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/messages/)',
+            ]),
+        });
+
+        return msg.channel.send({ embeds: [mcduEmbed] });
+    },
+};

--- a/src/commands/a32nx/mcdu.ts
+++ b/src/commands/a32nx/mcdu.ts
@@ -2,6 +2,8 @@ import { CommandDefinition } from '../../lib/command';
 import { CommandCategory } from '../../constants';
 import { makeEmbed, makeLines } from '../../lib/embed';
 
+const MCDU_BASE_URL = 'https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu';
+
 export const mcdu: CommandDefinition = {
     name: ['mcdu', 'mcdudoc'],
     description: 'Provides a link to the MCDU documentation',
@@ -10,23 +12,23 @@ export const mcdu: CommandDefinition = {
         const mcduEmbed = makeEmbed({
             title: 'FlyByWire A32NX | MCDU Documentation',
             description: makeLines([
-                'Please see our [MCDU documentation](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/) for information on the MCDU of the FlyByWire A32NX.',
+                `Please see our [MCDU documentation](${MCDU_BASE_URL}) for information on the MCDU of the FlyByWire A32NX.`,
                 '',
                 'If you\'d like to immediately go to a specific chapter please use the list below:',
-                '- [Overview](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/)',
-                '- [MCDU Interface](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/interface/)',
-                '- [DIR TO page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/dir/)',
-                '- [PROG page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/prog/)',
-                '- [PERF page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/perf/)',
-                '- [INIT page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/init/)',
-                '- [DATA page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/data/)',
-                '- [F-PLN page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/f-pln/)',
-                '- [RAD NAV page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/rad-nav/)',
-                '- [FUEL PRED page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/fuel-pred/)',
-                '- [SEC F-PLN page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/sec-f-plan/)',
-                '- [ATC COMM page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/atc-comm/)',
-                '- [MCDU MENU page](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/mcdu-menu/)',
-                '- [MCDU Messages](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/messages/)',
+                `- [Overview](${MCDU_BASE_URL})`,
+                `- [MCDU Interface](${MCDU_BASE_URL}/interface/)`,
+                `- [DIR TO page](${MCDU_BASE_URL}/dir/)`,
+                `- [PROG page](${MCDU_BASE_URL}/prog/)`,
+                `- [PERF page](${MCDU_BASE_URL}/perf/)`,
+                `- [INIT page](${MCDU_BASE_URL}/init/)`,
+                `- [DATA page](${MCDU_BASE_URL}/data/)`,
+                `- [F-PLN page](${MCDU_BASE_URL}/f-pln/)`,
+                `- [RAD NAV page](${MCDU_BASE_URL}/rad-nav/)`,
+                `- [FUEL PRED page](${MCDU_BASE_URL}/fuel-pred/)`,
+                `- [SEC F-PLN page](${MCDU_BASE_URL}/sec-f-plan/)`,
+                `- [ATC COMM page](${MCDU_BASE_URL}/atc-comm/)`,
+                `- [MCDU MENU page](${MCDU_BASE_URL}/mcdu-menu/)`,
+                `- [MCDU Messages](${MCDU_BASE_URL}/messages/)`,
             ]),
         });
 

--- a/src/commands/a32nx/remoteMcdu.ts
+++ b/src/commands/a32nx/remoteMcdu.ts
@@ -2,16 +2,16 @@ import { CommandDefinition } from '../../lib/command';
 import { CommandCategory } from '../../constants';
 import { makeEmbed } from '../../lib/embed';
 
-export const mcdu: CommandDefinition = {
-    name: ['remotemcdu', 'mcdu', 'remote'],
+export const remoteMcdu: CommandDefinition = {
+    name: ['remotemcdu', 'remote'],
     description: 'Provides a link to the FlyByWire remote MCDU feature guide',
     category: CommandCategory.A32NX,
     executor: (msg) => {
-        const mcduEmbed = makeEmbed({
+        const remoteMcduEmbed = makeEmbed({
             title: 'FlyByWire A32NX | Remote MCDU',
             description: 'Please see our [guide](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/web-mcdu/) on how to use the FlyByWire A32NX remote MCDU feature.',
         });
 
-        return msg.channel.send({ embeds: [mcduEmbed] });
+        return msg.channel.send({ embeds: [remoteMcduEmbed] });
     },
 };

--- a/src/commands/a32nx/remoteMcdu.ts
+++ b/src/commands/a32nx/remoteMcdu.ts
@@ -3,7 +3,7 @@ import { CommandCategory } from '../../constants';
 import { makeEmbed } from '../../lib/embed';
 
 export const remoteMcdu: CommandDefinition = {
-    name: ['remotemcdu', 'remote'],
+    name: 'remotemcdu',
     description: 'Provides a link to the FlyByWire remote MCDU feature guide',
     category: CommandCategory.A32NX,
     executor: (msg) => {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -144,6 +144,7 @@ import { verticalSpeedPriority } from './a32nx/verticalSpeedPriority';
 import { flyPadOS } from './a32nx/flyPadOS';
 import { simulationRate } from './support/simulationRate';
 import { dfd } from './general/dfd';
+import { mcdu } from './a32nx/mcdu';
 
 const commands: CommandDefinition[] = [
     ping,
@@ -290,6 +291,7 @@ const commands: CommandDefinition[] = [
     flyPadOS,
     simulationRate,
     dfd,
+    mcdu,
 ];
 
 const commandsObject: { [k: string]: CommandDefinition } = {};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -88,7 +88,7 @@ import { assistance } from './a32nx/assistance';
 import { ctd } from './support/ctd';
 import { hud } from './support/hud';
 import { fms } from './memes/fms';
-import { mcdu } from './a32nx/mcdu';
+import { remoteMcdu } from './a32nx/remoteMcdu';
 import { takeoffPerf } from './a32nx/takeoffPerf';
 import { manualleg } from './support/manualleg';
 import { oim } from './memes/oim';
@@ -234,7 +234,7 @@ const commands: CommandDefinition[] = [
     ctd,
     hud,
     fms,
-    mcdu,
+    remoteMcdu,
     takeoffPerf,
     manualleg,
     oim,


### PR DESCRIPTION
## feat: mcdu command for the detailed MCDU documentation

## Description

Advanced MCDU documentation command. Does require removing the `.mcdu` alias from the `.remotemcdu` command, als refactored the file for that to be in line.

Work in progress: pending flybywiresim/docs#191

## Test Results

<img width="591" alt="Screen Shot 2022-09-17 at 8 59 05 PM" src="https://user-images.githubusercontent.com/942391/190885330-f2c932d4-06fb-4865-9e92-8150d916edab.png">
<img width="592" alt="Screen Shot 2022-09-17 at 8 59 15 PM" src="https://user-images.githubusercontent.com/942391/190885333-a33c12cb-3aa4-407c-b81b-b0f7686c58ad.png">

## Discord Username
straks#7240
