### PR TITLE
fix: crash when banning a moderator

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ October 2022</small>
 
+- fix: crash when trying to ban a moderator (07/10/2022)
 - feat: add flypadabout command for flyPadOS and aircraft version (03/10/2022)
 
 Update <small>_ September 2022</small>

--- a/src/commands/moderation/ban.ts
+++ b/src/commands/moderation/ban.ts
@@ -4,6 +4,11 @@ import { CommandDefinition } from '../../lib/command';
 import { Channels, CommandCategory } from '../../constants';
 import { makeEmbed, makeLines } from '../../lib/embed';
 
+const moderatableFailEmbed = makeEmbed({
+    color: Colors.Red,
+    description: 'You can\'t ban a moderator!',
+});
+
 const modLogEmbed = (formattedDate, moderator: User, user: User, reason: string) => makeEmbed({
     color: Colors.Red,
     author: {
@@ -71,7 +76,7 @@ const failedBanEmbed = (user: User, error: any) => makeEmbed({
         {
             inline: false,
             name: 'Error',
-            value: error || 'No error provided',
+            value: error.toString() || 'No error provided',
         },
     ],
 });
@@ -129,6 +134,10 @@ export const ban: CommandDefinition = {
         const currentDate = new Date();
         const formattedDate: string = moment(currentDate).utcOffset(0).format('DD, MM, YYYY, HH:mm:ss');
         const modLogsChannel = msg.guild.channels.resolve(Channels.MOD_LOGS) as TextChannel | null;
+
+        if (!targetUser.moderatable) {
+            return msg.channel.send({ embeds: [moderatableFailEmbed] });
+        }
         try {
             await targetUser.send({ embeds: [dmEmbed(formattedDate, moderator, reason)] });
         } catch {


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description

Small fix to prevent a crash when banning a moderator. There was an error in the handling for when the bot had incorrect permissions. (Bot sits below Admin and Moderator roles, hence throwing an error when trying to ban - this is normal)

`!targetUser.moderatable` is now also used to prevent trying to ban a moderator in the first place.

<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results

![image](https://user-images.githubusercontent.com/67422707/194539852-186d2693-8e8d-4c25-8e25-0b9dbb7acbde.png)

![image](https://user-images.githubusercontent.com/67422707/194540057-ea913f57-a84e-4bf3-9e8a-903b0d83fc8d.png)

<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username

BenW#8484

<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
