### PR TITLE
refactor: update the ATC command for more clarity and more options

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+Update <small>_ November 2022</small>
+
+- refactor: update the ATC command for more clarity and more options (01/11/2022)
+
 Update <small>_ October 2022</small>
 
 - feat: scam protection now uses timeout instead of a 'muted' role (23/10/2022)

--- a/.github/command-docs.md
+++ b/.github/command-docs.md
@@ -8,7 +8,7 @@
 | .afloor                  | Provides a link to the Alpha Floor Tool-Tip                                                       | ---                                                    |
 | .airframe                | Provides a link to the updated Simbrief airframe                                                  | ---                                                    |
 | .assistance              | Explains to the user why assistance options should be disabled                                    | .assi <br> .as                                         |
-| .atc                     | Provides a link to the cFMS special notes section.                                                | ---                                                    |
+| .atc                     | Provides details on the use of the built-in ATC and a link to the cFMS special notes section.     | ---                                                    |
 | .audio                   | Provides support information about A32NX audio configuration                                      | ---                                                    |
 | .autoland                | Provides a link to the Autoland documentation                                                     | ---                                                    |
 | .autopilot               | Provides a link to the autopilot/fly-by-wire page within docs                                     | .ap                                                    |

--- a/src/commands/a32nx/atc.ts
+++ b/src/commands/a32nx/atc.ts
@@ -5,15 +5,30 @@ import { CommandCategory } from '../../constants';
 export const atc: CommandDefinition = {
     name: 'atc',
     category: CommandCategory.A32NX,
-    description: 'Provides a link to the cFMS special notes section.',
+    description: 'Provides details on the use of the built-in ATC and a link to the cFMS special notes section.',
     executor: (msg) => {
         const atcEmbed = makeEmbed({
-            title: 'FlyByWire A32NX | Default ATC',
+            title: 'FlyByWire A32NX | Using the built-in Microsoft Flight Simulator ATC',
             description: makeLines([
-                'To use the default ATC and/or world map flight plan import, you need to enable the **Sync MSFS Flight Plan** setting in the EFB Sim Options.',
-                '',
-                'Please read cFMS special notes [here.](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/cFMS/#special-notes)',
+                'There are multiple ways of using the built-in ATC of MSFS:',
             ]),
+            fields: [
+                {
+                    name: 'Synchronizing the MCDU flight plan back to MSFS ATC',
+                    value: 'In this mode, you only select a departure airport and gate (or runway). You should not select a destination airport. Once the EFB setting for **Sync MSFS Flight Plan** is set to **Safe**, any flight plan entered, or loaded, into the MCDU F-PLN page, will be synced to the MSFS ATC service.',
+                    inline: false,
+                },
+                {
+                    name: 'Loading the same flight plan in the World Planner and the MCDU',
+                    value: 'In this mode, the EFB setting for **Sync MSFS Flight Plan** should be set to **None**. You can then load a flight plan into the World Planner (for instance through exporting it from Simbrief, or by letting the World Planner build one for you) and once the aircraft has loaded and has been powered up, you enter or load the same flight plan in the MCDU.',
+                    inline: false,
+                },
+                {
+                    name: 'More information',
+                    value: 'Please read cFMS special notes [here.](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/cFMS/#special-notes)',
+                    inline: false,
+                },
+            ],
         });
 
         return msg.channel.send({ embeds: [atcEmbed] });


### PR DESCRIPTION
## refactor: update the ATC command for more clarity and more options

## Description

After discussions with some developers, it was suggested to enhance the ATC command and documentation to clarify that there's not only the sync method, but also just using the world planner itself, if users would like to. 

## Test Results

<img width="596" alt="Screen Shot 2022-10-31 at 7 19 04 PM" src="https://user-images.githubusercontent.com/942391/199144376-da4c3a9a-e9be-4490-b562-a57a12f1a3a4.png">


## Discord Username

straks#7240
