### PR TITLE
fix: bugfix where help subcommand was not working for tcedit

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ November 2022</small>
 
+- fix: bugfix where help subcommand was not working for tcedit (10/11/2022)
 - feat: Purge messages on ban (06/11/2022)
 - refactor: update youtube account information (06/11/2022)
 - fix: language on ATC command (06/11/2022)

--- a/src/commands/moderation/temporaryCommandEdit.ts
+++ b/src/commands/moderation/temporaryCommandEdit.ts
@@ -242,7 +242,7 @@ export const temporarycommandedit: CommandDefinition = {
         if (!hasPermittedRole) {
             return msg.channel.send({ embeds: [noPermEmbed] });
         }
-        if ((args.length < 1 && parseInt(args[1]) !== 0) || args[0] === 'help') {
+        if (!args || args === 'help') {
             return msg.channel.send({ embeds: [helpEmbed(evokedCommand)] });
         }
 


### PR DESCRIPTION
## fix: bugfix where help subcommand was not working for tcedit

## Description

A previous refactor of arg parsing broke the parsing of the help sub command, this fixes that. 

## Test Results

**Before**

<img width="477" alt="Screen Shot 2022-11-09 at 8 07 02 PM" src="https://user-images.githubusercontent.com/942391/200998325-40c1163a-bdbd-4a5f-bb7c-47785667526e.png">

**After**

<img width="602" alt="Screen Shot 2022-11-09 at 8 07 27 PM" src="https://user-images.githubusercontent.com/942391/200998382-c163441c-88bc-483e-93d4-1d55b7c8809c.png">


## Discord Username

straks#7240
HowNowBrownCrow#2591 for reporting and providing first fix proposal in Heavy-Division/heavy-division-bot#55 ( @nakajimayoshi )
