### PR TITLE
refactor: sort commands in help alphabetically

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ November 2022</small>
 
+- refactor: sort commands in help alphabetically (20/11/2022)
 - feat: SimBridge logs command (14/11/2022)
 - feat: added windows screenshot command (14/11/2022)
 - fix: bugfix where help subcommand was not working for tcedit (14/11/2022)

--- a/src/commands/utils/help.ts
+++ b/src/commands/utils/help.ts
@@ -151,6 +151,9 @@ function renderAllCategories(): EmbedField[] {
     // Remove duplicates by name
     commandArray = commandArray.filter((v, i, a) => a.findIndex((t) => t.name === v.name) === i);
 
+    // Sort commands
+    commandArray.sort((a, b) => a.name[0].localeCompare(b.name[0]));
+
     // Group all commands by their category
     const groupedCommands = Object.values(CommandCategory)
         .map((category) => {


### PR DESCRIPTION
## refactor: sort commands in help alphabetically

## Description

The commands in the DM for help are not alphabetically sorted, this is confusing. This PR fixes that.

NOTE: In the commands/index.ts, it makes sure that the list of names is _always_ an array/list:
https://github.com/flybywiresim/discord-bot/blob/ea7cbf3af47b5089b5b719b13ec120b11fe61bc3/src/commands/index.ts#L316

## Test Results

<img width="597" alt="Screen Shot 2022-11-19 at 9 26 05 PM" src="https://user-images.githubusercontent.com/942391/202887165-1dee4e09-3ef7-4d70-9f4e-2404e4d0689a.png">
<img width="588" alt="Screen Shot 2022-11-19 at 9 26 14 PM" src="https://user-images.githubusercontent.com/942391/202887166-2ab791ec-fe68-4926-9de7-ae69c8384a91.png">

## Discord Username

straks#7240
