### PR TITLE
fix: forum post handler was too fast for Discord API and tried to post before the thread really existed

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ December 2022</small>
 
+- fix: forum post handler was too fast for Discord API and tried to post before the thread really existed (20/12/2022)
 - feat: stickies for forum posts which get posted on forum post create (19/12/2022)
 - refactor: outdated information + links in commands (08/12/2022)
 - fix: fix latlong image typo and prime meridian alignment (04/12/2022)

--- a/src/handlers/forumPostCreate.ts
+++ b/src/handlers/forumPostCreate.ts
@@ -40,7 +40,7 @@ module.exports = {
             // eslint-disable-next-line no-await-in-loop
             await new Promise((f) => setTimeout(f, SLEEP_TIMER));
             // eslint-disable-next-line no-await-in-loop
-            await thread.messages.fetch({ limit: 1, cache: false });
+            await thread.messages.fetch({ limit: 1 });
             retryCount--;
         }
         if (thread.messageCount > 0) {


### PR DESCRIPTION
## fix: forum post handler was too fast for Discord API and tried to post before the thread really existed

## Description

The Forum Post create Handler to post a sticky message into each Forum Post (Thread) could encounter a race condition where it tried to post the sticky message before Discord was finished setting up the thread properly. 

This caused an exception and the bot to crash. 

The internal exception is: ```Exception has occurred: DiscordAPIError[40058]: Cannot message this thread until after the post author has sent an initial message```

This is more likely on messages that require more processing by the Discord API, most easy way to reproduce it to post a (very) large image as part of the new Forum Post.

Note: Even with a large image, it doesn't always trigger the race condition. Testing revealed about 80% chance with an image of 4.5MB in size. The smaller the size, the less likely it is to trigger the race condition.

## Test Results

[![FBW Discord Bot - Fix Forum Post create handler](https://img.youtube.com/vi/TGzOVcTe7HE/0.jpg)](https://www.youtube.com/watch?v=TGzOVcTe7HE)

## Discord Username

straks#7240
