### PR TITLE
refactor: add flightplanning alias to atc command

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ December 2022</small>
 
+- refactor: add flightplanning alias to atc command (26/12/2022)
 - refactor: update atc command with new link and information (26/12/2022)
 - feat: stickies for forum posts which get posted on forum post create (19/12/2022)
 - refactor: outdated information + links in commands (08/12/2022)

--- a/.github/command-docs.md
+++ b/.github/command-docs.md
@@ -8,7 +8,7 @@
 | .afloor                  | Provides a link to the Alpha Floor Tool-Tip                                                       | ---                                                    |
 | .airframe                | Provides a link to the updated Simbrief airframe                                                  | ---                                                    |
 | .assistance              | Explains to the user why assistance options should be disabled                                    | .assi <br> .as                                         |
-| .atc                     | Provides details on the use of the built-in ATC and a link to the cFMS special notes section.     | ---                                                    |
+| .atc                     | Provides details on the use of the built-in ATC and on Flight Planning in general                 | .flightplanning                                        |
 | .audio                   | Provides support information about A32NX audio configuration                                      | ---                                                    |
 | .autoland                | Provides a link to the Autoland documentation                                                     | ---                                                    |
 | .autopilot               | Provides a link to the autopilot/fly-by-wire page within docs                                     | .ap                                                    |

--- a/src/commands/aircraft/atc.ts
+++ b/src/commands/aircraft/atc.ts
@@ -30,7 +30,7 @@ const genericAtcEmbed = makeEmbed({
 });
 
 export const atc: MessageCommandDefinition = {
-    name: 'atc',
+    name: ['atc', 'flightplanning'],
     category: CommandCategory.AIRCRAFT,
     description: 'Provides details on the use of the built-in ATC and a link to the cFMS special notes section.',
     genericEmbed: genericAtcEmbed,


### PR DESCRIPTION
## refactor: add flightplanning alias to atc command

## Description

Simple alias for the ATC command now that it includes more details on flight planning. 

## Test Results

<img width="588" alt="Screen Shot 2022-12-26 at 10 28 53 PM" src="https://user-images.githubusercontent.com/942391/209584369-c79364b0-d1ef-4eb4-902d-45a8ed717c35.png">


## Discord Username

straks#7240
