### PR TITLE
feat: slowmode with timeout and introducing proper scheduler

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,7 @@ Update <small>_ January 2023</small>
 
 Update <small>_ December 2022</small>
 
+- feat: slowmode with timeout and introducing proper scheduler (31/12/2022)
 - fix: manualleg image of the doc site and add alias (26/12/2022)
 - feat: navroutetypes command to show different navigation route types (26/12/2022)
 - fix: code typo on simbridgeLog command (26/12/2022)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Update <small>_ January 2023</small>
 
-- feat: slowmode with timeout and introducing proper scheduler (10/01/2023)
+- feat: slowmode with timeout and introducing proper scheduler (20/01/2023)
 - feat: Github issues templates and accompanying command (10/01/2023)
 - feat: navigraph discord link, requires a small change in navigraphNavdata command (02/01/2023)
 - fix: roleinfo showing wrong count because of caching (02/01/2023)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ January 2023</small>
 
+- feat: slowmode with timeout and introducing proper scheduler (10/01/2023)
 - feat: Github issues templates and accompanying command (10/01/2023)
 - feat: navigraph discord link, requires a small change in navigraphNavdata command (02/01/2023)
 - fix: roleinfo showing wrong count because of caching (02/01/2023)
@@ -9,7 +10,6 @@ Update <small>_ January 2023</small>
 
 Update <small>_ December 2022</small>
 
-- feat: slowmode with timeout and introducing proper scheduler (31/12/2022)
 - fix: manualleg image of the doc site and add alias (26/12/2022)
 - feat: navroutetypes command to show different navigation route types (26/12/2022)
 - fix: code typo on simbridgeLog command (26/12/2022)

--- a/.github/command-docs.md
+++ b/.github/command-docs.md
@@ -176,6 +176,7 @@
 | .faq                  | Sends the FAQ                                                                                           | ---                                        |
 | .roleassignment       | Sends the role assignment messages                                                                      | ---                                        |
 | .rules                | Sends the rules                                                                                         | ---                                        |
+| .slowmode             | Sets slow mode for a channel and is capable of automatically disabling it after a timeout.              | ---                                        |
 | .sticky               | Manage sticky messages which are posted in Forum Posts when a new post is created                       | ---                                        |
 | .temporarycommandedit | Manage temporary commands, which are simple output commands to highlight temporary situations to users. | .tempcommandedit <br> .tcedit <br> .tcmod  |
 | .timeout              | ---                                                                                                     | ---                                        |

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "AGPLv3",
       "dependencies": {
         "@elastic/ecs-winston-format": "^1.1.0",
+        "agenda": "^5.0.0",
         "bad-words": "^3.0.4",
         "cowsay": "^1.5.0",
         "discord.js": "^14.0.3",
@@ -30,6 +31,1072 @@
         "nodemon": "^2.0.16",
         "ts-node": "^10.4.0",
         "typescript": "^4.3.5"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
+      "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.241.0.tgz",
+      "integrity": "sha512-9X/MwcnSwWfB0ijggFjyBWa4gtlUAyI39eBaVSE0AxMcgLlHKedEK6w5F1RrtvWqb7KyJDsyAysVecU4E9zQQQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.241.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.241.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.241.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
+      "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.241.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
+      "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.241.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
+      "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.241.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-sdk-sts": "3.226.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.241.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+      "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.241.0.tgz",
+      "integrity": "sha512-e2hlXWG9DH93uVe2wHIUrUOrgZTLzCV3gBd10D3/usSzS4FvVVU7OmidnRPYCLLnt3EvnL5b4REOedO1q8hv8g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.241.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
+      "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
+      "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
+      "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.241.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
+      "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-ini": "3.241.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.241.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
+      "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
+      "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.241.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/token-providers": "3.241.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
+      "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.241.0.tgz",
+      "integrity": "sha512-J3Q45t1o35OhUI6gWks7rmosPT+mFWXiaHl2LST509Ovjwx6SFs2PvbGP6n7xqUzxyq5Rk6FzZBwB8ItuAa6Qw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.241.0",
+        "@aws-sdk/client-sso": "3.241.0",
+        "@aws-sdk/client-sts": "3.241.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.241.0",
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-ini": "3.241.0",
+        "@aws-sdk/credential-provider-node": "3.241.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.241.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
+      "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
+      "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
+      "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
+      "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
+      "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
+      "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
+      "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
+      "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
+      "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
+      "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
+      "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
+      "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
+      "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
+      "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
+      "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
+      "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+      "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+      "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+      "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+      "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+      "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
+      "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
+      "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.241.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+      "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
+      "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
+      "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
+      "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+      "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-retry": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
+      "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
+      "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
+      "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -714,6 +1781,39 @@
       "resolved": "https://registry.npmjs.org/after-all-results/-/after-all-results-2.0.0.tgz",
       "integrity": "sha512-2zHEyuhSJOuCrmas9YV0YL/MFCWLxe1dS6k/ENhgYrb/JqyMnadLN4iIAc9kkZrbElMDyyAGH/0J18OPErOWLg=="
     },
+    "node_modules/agenda": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/agenda/-/agenda-5.0.0.tgz",
+      "integrity": "sha512-jOoa7PvARpst/y2PI8h0wph4NmcjYJ/4wzFhQcHUbNgN+Hte/9h/MzKE0ZmHfIwdsSlnv3rhbBQ3Zd/gwFkThg==",
+      "dependencies": {
+        "cron-parser": "^3.5.0",
+        "date.js": "~0.3.3",
+        "debug": "~4.3.4",
+        "human-interval": "~2.0.1",
+        "moment-timezone": "~0.5.37",
+        "mongodb": "^4.11.0"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      }
+    },
+    "node_modules/agenda/node_modules/mongodb": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.13.0.tgz",
+      "integrity": "sha512-+taZ/bV8d1pYuHL4U+gSwkhmDrwkWbH1l4aah4YpmpscMwgFBkufIKxgP/G7m87/NUuQzc2Z75ZTI7ZOyqZLbw==",
+      "dependencies": {
+        "bson": "^4.7.0",
+        "mongodb-connection-string-url": "^2.5.4",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "saslprep": "^1.0.3"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
@@ -1072,6 +2172,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "optional": true
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1103,9 +2209,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "4.6.5",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.5.tgz",
-      "integrity": "sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
+      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
       "dependencies": {
         "buffer": "^5.6.0"
       },
@@ -1432,6 +2538,18 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "node_modules/cron-parser": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-3.5.0.tgz",
+      "integrity": "sha512-wyVZtbRs6qDfFd8ap457w3XVntdvqcwBGxBoTvJQH9KGVKL/fB+h2k3C8AqiVxvUQKN1Ps/Ns46CNViOpVDhfQ==",
+      "dependencies": {
+        "is-nan": "^1.3.2",
+        "luxon": "^1.26.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1451,6 +2569,27 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
+    },
+    "node_modules/date.js": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/date.js/-/date.js-0.3.3.tgz",
+      "integrity": "sha512-HgigOS3h3k6HnW011nAb43c5xx5rBXk8P2v/WIT9Zv4koIaVXiH2BURguI78VVp+5Qc076T7OR378JViCnZtBw==",
+      "dependencies": {
+        "debug": "~3.1.0"
+      }
+    },
+    "node_modules/date.js/node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/date.js/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -2436,6 +3575,22 @@
         "end-of-stream": "^1.4.1"
       }
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "optional": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -2847,6 +4002,14 @@
         "next-line": "^1.1.0"
       }
     },
+    "node_modules/human-interval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/human-interval/-/human-interval-2.0.1.tgz",
+      "integrity": "sha512-r4Aotzf+OtKIGQCB3odUowy4GfUDTy3aTWTfLd7ZF2gBCy3XW3v/dJLRefZnOFFnjqs5B1TypvS8WarpBkYUNQ==",
+      "dependencies": {
+        "numbered": "^1.1.0"
+      }
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -3091,6 +4254,21 @@
       "integrity": "sha512-RPQc/s9yBHSvpi+hs9dYiJ2cuFeU6x3TyyIp8O2H6SKEltIvJOzRj9ToyvcStDvPR/pS4rxgr1oBFajQjZ2Szg==",
       "dependencies": {
         "is-finite": "^1.0.0"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-native": {
@@ -3391,6 +4569,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/luxon": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
+      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -3538,6 +4724,17 @@
         "node": "*"
       }
     },
+    "node_modules/moment-timezone": {
+      "version": "0.5.40",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.40.tgz",
+      "integrity": "sha512-tWfmNkRYmBkPJz5mr9GVDn9vRlVZOTe6yqY92rFxiOdWXbjaR0+9LwQnZGGuNR63X456NqmEkbskte8tWL5ePg==",
+      "dependencies": {
+        "moment": ">= 2.9.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/mongodb": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.8.1.tgz",
@@ -3556,9 +4753,9 @@
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.3.tgz",
-      "integrity": "sha512-f+/WsED+xF4B74l3k9V/XkTVj5/fxFH2o5ToKXd8Iyi5UhM+sO9u0Ape17Mvl/GkZaFtM0HQnzAG5OTmhKw+tQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
       "dependencies": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
@@ -3767,6 +4964,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/numbered": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/numbered/-/numbered-1.1.0.tgz",
+      "integrity": "sha512-pv/ue2Odr7IfYOO0byC1KgBI10wo5YDauLhxY6/saNzAdAs0r1SotGCPzzCLNPL0xtrAwWRialLu23AAu9xO1g=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -4647,9 +5849,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.0.tgz",
-      "integrity": "sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
       "dependencies": {
         "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
@@ -4906,6 +6108,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "optional": true
     },
     "node_modules/strtok3": {
       "version": "7.0.0",
@@ -5322,6 +6530,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -5647,6 +6864,912 @@
     }
   },
   "dependencies": {
+    "@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+      "optional": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
+      "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-cognito-identity": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.241.0.tgz",
+      "integrity": "sha512-9X/MwcnSwWfB0ijggFjyBWa4gtlUAyI39eBaVSE0AxMcgLlHKedEK6w5F1RrtvWqb7KyJDsyAysVecU4E9zQQQ==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.241.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.241.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.241.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
+      "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.241.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
+      "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.241.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
+      "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.241.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-sdk-sts": "3.226.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.241.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+      "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.241.0.tgz",
+      "integrity": "sha512-e2hlXWG9DH93uVe2wHIUrUOrgZTLzCV3gBd10D3/usSzS4FvVVU7OmidnRPYCLLnt3EvnL5b4REOedO1q8hv8g==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.241.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
+      "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
+      "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
+      "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.241.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
+      "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-ini": "3.241.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.241.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
+      "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
+      "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-sso": "3.241.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/token-providers": "3.241.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
+      "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-providers": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.241.0.tgz",
+      "integrity": "sha512-J3Q45t1o35OhUI6gWks7rmosPT+mFWXiaHl2LST509Ovjwx6SFs2PvbGP6n7xqUzxyq5Rk6FzZBwB8ItuAa6Qw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.241.0",
+        "@aws-sdk/client-sso": "3.241.0",
+        "@aws-sdk/client-sts": "3.241.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.241.0",
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-ini": "3.241.0",
+        "@aws-sdk/credential-provider-node": "3.241.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.241.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
+      "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
+      "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
+      "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
+      "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-endpoint": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
+      "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
+      "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
+      "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
+      "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
+      "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
+      "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
+      "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
+      "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
+      "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
+      "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
+      "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
+      "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/abort-controller": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+      "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+      "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+      "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+      "optional": true
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+      "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+      "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
+      "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
+      "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-sso-oidc": "3.241.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+      "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
+      "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
+      "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
+      "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+      "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-retry": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
+      "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
+      "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.226.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
+      "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -6152,6 +8275,33 @@
       "resolved": "https://registry.npmjs.org/after-all-results/-/after-all-results-2.0.0.tgz",
       "integrity": "sha512-2zHEyuhSJOuCrmas9YV0YL/MFCWLxe1dS6k/ENhgYrb/JqyMnadLN4iIAc9kkZrbElMDyyAGH/0J18OPErOWLg=="
     },
+    "agenda": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/agenda/-/agenda-5.0.0.tgz",
+      "integrity": "sha512-jOoa7PvARpst/y2PI8h0wph4NmcjYJ/4wzFhQcHUbNgN+Hte/9h/MzKE0ZmHfIwdsSlnv3rhbBQ3Zd/gwFkThg==",
+      "requires": {
+        "cron-parser": "^3.5.0",
+        "date.js": "~0.3.3",
+        "debug": "~4.3.4",
+        "human-interval": "~2.0.1",
+        "moment-timezone": "~0.5.37",
+        "mongodb": "^4.11.0"
+      },
+      "dependencies": {
+        "mongodb": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.13.0.tgz",
+          "integrity": "sha512-+taZ/bV8d1pYuHL4U+gSwkhmDrwkWbH1l4aah4YpmpscMwgFBkufIKxgP/G7m87/NUuQzc2Z75ZTI7ZOyqZLbw==",
+          "requires": {
+            "@aws-sdk/credential-providers": "^3.186.0",
+            "bson": "^4.7.0",
+            "mongodb-connection-string-url": "^2.5.4",
+            "saslprep": "^1.0.3",
+            "socks": "^2.7.1"
+          }
+        }
+      }
+    },
     "agentkeepalive": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
@@ -6428,6 +8578,12 @@
         }
       }
     },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "optional": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -6456,9 +8612,9 @@
       }
     },
     "bson": {
-      "version": "4.6.5",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.5.tgz",
-      "integrity": "sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
+      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
       "requires": {
         "buffer": "^5.6.0"
       }
@@ -6698,6 +8854,15 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "cron-parser": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-3.5.0.tgz",
+      "integrity": "sha512-wyVZtbRs6qDfFd8ap457w3XVntdvqcwBGxBoTvJQH9KGVKL/fB+h2k3C8AqiVxvUQKN1Ps/Ns46CNViOpVDhfQ==",
+      "requires": {
+        "is-nan": "^1.3.2",
+        "luxon": "^1.26.0"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -6714,6 +8879,29 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
+    },
+    "date.js": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/date.js/-/date.js-0.3.3.tgz",
+      "integrity": "sha512-HgigOS3h3k6HnW011nAb43c5xx5rBXk8P2v/WIT9Zv4koIaVXiH2BURguI78VVp+5Qc076T7OR378JViCnZtBw==",
+      "requires": {
+        "debug": "~3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        }
+      }
     },
     "debug": {
       "version": "4.3.4",
@@ -7482,6 +9670,15 @@
         "end-of-stream": "^1.4.1"
       }
     },
+    "fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "optional": true,
+      "requires": {
+        "strnum": "^1.0.5"
+      }
+    },
     "fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -7785,6 +9982,14 @@
         "next-line": "^1.1.0"
       }
     },
+    "human-interval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/human-interval/-/human-interval-2.0.1.tgz",
+      "integrity": "sha512-r4Aotzf+OtKIGQCB3odUowy4GfUDTy3aTWTfLd7ZF2gBCy3XW3v/dJLRefZnOFFnjqs5B1TypvS8WarpBkYUNQ==",
+      "requires": {
+        "numbered": "^1.1.0"
+      }
+    },
     "humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -7952,6 +10157,15 @@
       "integrity": "sha512-RPQc/s9yBHSvpi+hs9dYiJ2cuFeU6x3TyyIp8O2H6SKEltIvJOzRj9ToyvcStDvPR/pS4rxgr1oBFajQjZ2Szg==",
       "requires": {
         "is-finite": "^1.0.0"
+      }
+    },
+    "is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "is-native": {
@@ -8186,6 +10400,11 @@
         "yallist": "^4.0.0"
       }
     },
+    "luxon": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
+      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ=="
+    },
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -8297,6 +10516,14 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
+    "moment-timezone": {
+      "version": "0.5.40",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.40.tgz",
+      "integrity": "sha512-tWfmNkRYmBkPJz5mr9GVDn9vRlVZOTe6yqY92rFxiOdWXbjaR0+9LwQnZGGuNR63X456NqmEkbskte8tWL5ePg==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
     "mongodb": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.8.1.tgz",
@@ -8310,9 +10537,9 @@
       }
     },
     "mongodb-connection-string-url": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.3.tgz",
-      "integrity": "sha512-f+/WsED+xF4B74l3k9V/XkTVj5/fxFH2o5ToKXd8Iyi5UhM+sO9u0Ape17Mvl/GkZaFtM0HQnzAG5OTmhKw+tQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
       "requires": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
@@ -8471,6 +10698,11 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
+    },
+    "numbered": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/numbered/-/numbered-1.1.0.tgz",
+      "integrity": "sha512-pv/ue2Odr7IfYOO0byC1KgBI10wo5YDauLhxY6/saNzAdAs0r1SotGCPzzCLNPL0xtrAwWRialLu23AAu9xO1g=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -9123,9 +11355,9 @@
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
     },
     "socks": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.0.tgz",
-      "integrity": "sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
       "requires": {
         "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
@@ -9325,6 +11557,12 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "optional": true
     },
     "strtok3": {
       "version": "7.0.0",
@@ -9633,6 +11871,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "AGPLv3",
   "dependencies": {
     "@elastic/ecs-winston-format": "^1.1.0",
+    "agenda": "^5.0.0",
     "bad-words": "^3.0.4",
     "cowsay": "^1.5.0",
     "discord.js": "^14.0.3",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -159,6 +159,7 @@ import { navRouteTypes } from './general/navRouteTypes';
 import { cacheUpdate } from './moderation/cacheUpdate';
 import { navigraph } from './general/navigraph';
 import { botIssue } from './support/botIssue';
+import { slowMode } from './moderation/slowmode';
 
 const commands: BaseCommandDefinition[] = [
     typeCommand,
@@ -320,6 +321,7 @@ const commands: BaseCommandDefinition[] = [
     cacheUpdate,
     navigraph,
     botIssue,
+    slowMode,
 ];
 
 const commandsObject: { [k: string]: BaseCommandDefinition } = {};

--- a/src/commands/moderation/slowmode.ts
+++ b/src/commands/moderation/slowmode.ts
@@ -160,6 +160,9 @@ export const slowMode: CommandDefinition = {
             }
 
             const { rateLimit, timeout } = regexMatches.groups;
+            if (parseInt(rateLimit) > 21600) {
+                return msg.channel.send({ embeds: [missingInfoEmbed('Set', `The slow mode setting can not be over 21600 seconds (6h). Check \`${evokedCommand} help\` for more details.`)] });
+            }
 
             try {
                 if (slowmodeChannel.type === ChannelType.GuildForum || slowmodeChannel.type === ChannelType.GuildText || slowmodeChannel.type === ChannelType.PrivateThread || slowmodeChannel.type === ChannelType.PublicThread) {
@@ -167,27 +170,27 @@ export const slowMode: CommandDefinition = {
                     if (scheduler) {
                         await scheduler.cancel({ name: 'autoDisableSlowMode', data: { channelId } });
                         if (timeout) {
-                            let timoutMillis: number;
+                            let timeoutMillis: number;
                             switch (timeout[timeout.length - 1].toLowerCase()) {
                             default: {
                                 // defaults to minutes; 'm' will also run this block
-                                timoutMillis = parseInt(timeout.replace('s', '')) * TimeConversions.SECONDS_TO_MILLISECONDS;
+                                timeoutMillis = parseInt(timeout.replace('s', '')) * TimeConversions.SECONDS_TO_MILLISECONDS;
                                 break;
                             }
                             case 'm': {
-                                timoutMillis = parseInt(timeout.replace('m', '')) * TimeConversions.MINUTES_TO_MILLISECONDS;
+                                timeoutMillis = parseInt(timeout.replace('m', '')) * TimeConversions.MINUTES_TO_MILLISECONDS;
                                 break;
                             }
                             case 'h': {
-                                timoutMillis = parseInt(timeout.replace('h', '')) * TimeConversions.HOURS_TO_MILLISECONDS;
+                                timeoutMillis = parseInt(timeout.replace('h', '')) * TimeConversions.HOURS_TO_MILLISECONDS;
                                 break;
                             }
                             case 'd': {
-                                timoutMillis = parseInt(timeout.replace('d', '')) * TimeConversions.DAYS_TO_MILLISECONDS;
+                                timeoutMillis = parseInt(timeout.replace('d', '')) * TimeConversions.DAYS_TO_MILLISECONDS;
                                 break;
                             }
                             }
-                            const executionDate: Date = new Date(Date.now() + timoutMillis);
+                            const executionDate: Date = new Date(Date.now() + timeoutMillis);
                             await scheduler.schedule(executionDate, 'autoDisableSlowMode', { channelId });
                         }
                     }

--- a/src/commands/moderation/slowmode.ts
+++ b/src/commands/moderation/slowmode.ts
@@ -45,7 +45,7 @@ const helpEmbed = (evokedCommand: String) => makeEmbed({
 });
 
 const failedEmbed = (action: string, channel: string) => makeEmbed({
-    title: `Slow Message - ${action} failed`,
+    title: `Slow Mode - ${action} failed`,
     description: `Failed to ${action} the slow mode for channel <#${channel}>.`,
     color: Colors.Red,
 });

--- a/src/commands/moderation/slowmode.ts
+++ b/src/commands/moderation/slowmode.ts
@@ -1,0 +1,249 @@
+import { Colors, EmbedField, TextChannel, ChannelType } from 'discord.js';
+import { CommandDefinition } from '../../lib/command';
+import { Roles, Channels, CommandCategory } from '../../constants';
+import { makeEmbed } from '../../lib/embed';
+import { getScheduler } from '../../lib/scheduler';
+import { client } from '../..';
+
+const permittedRoles = [
+    Roles.ADMIN_TEAM,
+    Roles.MODERATION_TEAM,
+];
+
+enum TimeConversions {
+    SECONDS_TO_MILLISECONDS = 1000,
+    MINUTES_TO_MILLISECONDS = 60 * 1000,
+    HOURS_TO_MILLISECONDS = 60 * 60 * 1000,
+    DAYS_TO_MILLISECONDS = 60 * 60 * 24 * 1000,
+}
+
+const helpEmbed = (evokedCommand: String) => makeEmbed({
+    title: 'Manage Slow Mode - Help',
+    description: 'A command to set and manage slow mode for channels.',
+    fields: [
+        {
+            name: 'Channel ID parameter',
+            value: 'If you do not provide a Channel ID, the command applies to the channel in which it is executed.',
+            inline: false,
+        },
+        {
+            name: 'Disable Timer parameter',
+            value: 'The disable timer needs to be provided with an indication like s, m, h or d. Which respectively stand for seconds, minutes, hours or days.',
+            inline: false,
+        },
+        {
+            name: `Setting slow mode: \`${evokedCommand} set [channel id] <slow mode seconds> [disable timer]\``,
+            value: 'Sets slow mode for a channel in seconds. Can optionally schedule disabling slow mode. The maximum value of slow mode seconds is 21600 (6h).',
+            inline: false,
+        },
+        {
+            name: `Disable slow mode: \`${evokedCommand} disable [channel id]\``,
+            value: 'Disables slow mode on channel. Automatically removes any scheduled removal.',
+            inline: false,
+        },
+    ],
+});
+
+const failedEmbed = (action: string, channel: string) => makeEmbed({
+    title: `Slow Message - ${action} failed`,
+    description: `Failed to ${action} the slow mode for channel <#${channel}>.`,
+    color: Colors.Red,
+});
+
+const modLogEmbed = (action: string, fields: any, color: number) => makeEmbed({
+    title: `Slow Mode - ${action}`,
+    fields,
+    color,
+});
+
+const missingInfoEmbed = (action: string, information: string) => makeEmbed({
+    title: `Slow Mode - ${action} - missing information`,
+    description: `${information}`,
+    color: Colors.Red,
+});
+
+const missingChannelEmbed = (channel: string) => makeEmbed({
+    title: 'Slow Mode - Channel does not exist',
+    description: `The Channel ID ${channel} does not refer to an existing Text or Forum channel, or a Thread. Please provide a valid channel.`,
+    color: Colors.Red,
+});
+
+const noChannelEmbed = (action:string, channelName: string) => makeEmbed({
+    title: `Slow Mode - ${action} - No ${channelName} channel`,
+    description: `The command was successful, but no message to ${channelName} was sent. Please check the channel still exists.`,
+    color: Colors.Yellow,
+});
+
+const noSchedulerEmbed = makeEmbed({
+    title: 'Slow Mode - No scheduler',
+    description: 'Could not find an active scheduler. No automatic disable can be scheduled.',
+    color: Colors.Red,
+});
+
+const noPermEmbed = makeEmbed({
+    title: 'Slow Mode - Permission missing',
+    description: 'You do not have permission to use this command.',
+    color: Colors.Red,
+});
+
+const slowModeEmbedField = (moderator: string, channel: string, slowmode: string, timeout: string): EmbedField[] => [
+    {
+        inline: true,
+        name: 'Channel',
+        value: `<#${channel}>`,
+    },
+    {
+        inline: true,
+        name: 'Slow mode limit',
+        value: slowmode,
+    },
+    {
+        inline: true,
+        name: 'Auto disable timeout',
+        value: timeout,
+    },
+    {
+        inline: true,
+        name: 'Moderator',
+        value: moderator,
+    },
+];
+
+export const slowMode: CommandDefinition = {
+    name: ['slowmode'],
+    description: 'Manages slow mode for channels and potentially disable slow mode after a certain time.',
+    category: CommandCategory.MODERATION,
+    executor: async (msg) => {
+        const subCommands = ['set', 'disable'];
+        const scheduler = getScheduler();
+        if (!scheduler) {
+            await msg.channel.send({ embeds: [noSchedulerEmbed] });
+        }
+
+        const hasPermittedRole = msg.member.roles.cache.some((role) => permittedRoles.map((r) => r.toString()).includes(role.id));
+        if (!hasPermittedRole) {
+            return msg.channel.send({ embeds: [noPermEmbed] });
+        }
+
+        const modLogsChannel = client.channels.resolve(Channels.MOD_LOGS) as TextChannel | null;
+        const { author } = msg;
+        const [evokedCommand] = msg.content.trim().split(/\s+/);
+        const args = msg.content.replace(evokedCommand, '').trim();
+        if (!args || args === 'help') {
+            return msg.channel.send({ embeds: [helpEmbed(evokedCommand)] });
+        }
+
+        let [subCommand] = args.split(/\s+/);
+        let subArgs = args.replace(subCommand, '').trim();
+        if (!subCommands.includes(subCommand)) {
+            subCommand = 'set';
+            subArgs = args;
+        }
+
+        let { channelId } = msg;
+        const regexCheck = /^(?:(?<channelId>[\d]{6,}))\s*.*$/s;
+        const regexMatches = subArgs.match(regexCheck);
+        if (regexMatches && regexMatches.groups.channelId) {
+            ({ channelId } = regexMatches.groups);
+            subArgs = subArgs.replace(channelId, '').trim();
+        }
+        const slowmodeChannel = msg.guild.channels.resolve(channelId);
+        if (!slowmodeChannel || [ChannelType.GuildText, ChannelType.GuildForum, ChannelType.PublicThread, ChannelType.PrivateThread].indexOf(slowmodeChannel.type) === -1) {
+            return msg.channel.send({ embeds: [missingChannelEmbed(channelId)] });
+        }
+
+        if (subCommand === 'set') {
+            const regexCheck = /^(?<rateLimit>[\d]+)(?:\s+(?<timeout>[\d]+[s|m|h|d]))?\s*$/s;
+            const regexMatches = subArgs.toLowerCase().match(regexCheck);
+            if (regexMatches === null || !regexMatches.groups.rateLimit) {
+                return msg.channel.send({ embeds: [missingInfoEmbed('Set', `You need to provide the expected format to set the slow mode for a channel. Check \`${evokedCommand} help\` for more details.`)] });
+            }
+
+            const { rateLimit, timeout } = regexMatches.groups;
+
+            try {
+                if (slowmodeChannel.type === ChannelType.GuildForum || slowmodeChannel.type === ChannelType.GuildText || slowmodeChannel.type === ChannelType.PrivateThread || slowmodeChannel.type === ChannelType.PublicThread) {
+                    await slowmodeChannel.setRateLimitPerUser(parseInt(rateLimit), 'Slow mode enabled through bot');
+                    if (scheduler) {
+                        await scheduler.cancel({ name: 'autoDisableSlowMode', data: { channelId } });
+                        if (timeout) {
+                            let timoutMillis: number;
+                            switch (timeout[timeout.length - 1].toLowerCase()) {
+                            default: {
+                                // defaults to minutes; 'm' will also run this block
+                                timoutMillis = parseInt(timeout.replace('s', '')) * TimeConversions.SECONDS_TO_MILLISECONDS;
+                                break;
+                            }
+                            case 'm': {
+                                timoutMillis = parseInt(timeout.replace('m', '')) * TimeConversions.MINUTES_TO_MILLISECONDS;
+                                break;
+                            }
+                            case 'h': {
+                                timoutMillis = parseInt(timeout.replace('h', '')) * TimeConversions.HOURS_TO_MILLISECONDS;
+                                break;
+                            }
+                            case 'd': {
+                                timoutMillis = parseInt(timeout.replace('d', '')) * TimeConversions.DAYS_TO_MILLISECONDS;
+                                break;
+                            }
+                            }
+                            const executionDate: Date = new Date(Date.now() + timoutMillis);
+                            await scheduler.schedule(executionDate, 'autoDisableSlowMode', { channelId });
+                        }
+                    }
+                }
+            } catch {
+                return msg.channel.send({ embeds: [failedEmbed('Set', channelId)] });
+            }
+
+            try {
+                await modLogsChannel.send({
+                    embeds: [modLogEmbed('Set',
+                        slowModeEmbedField(
+                            author.toString(),
+                            channelId,
+                            `${rateLimit}s`,
+                            timeout && scheduler ? timeout : 'None',
+                        ),
+                        Colors.Green)],
+                });
+            } catch {
+                msg.channel.send({ embeds: [noChannelEmbed('Set', 'Mod Log')] });
+            }
+
+            return msg.react('✅');
+        }
+
+        if (subCommand === 'disable') {
+            try {
+                if (slowmodeChannel.type === ChannelType.GuildForum || slowmodeChannel.type === ChannelType.GuildText || slowmodeChannel.type === ChannelType.PrivateThread || slowmodeChannel.type === ChannelType.PublicThread) {
+                    await slowmodeChannel.setRateLimitPerUser(0, 'Slow mode disabled through bot');
+                    if (scheduler) {
+                        await scheduler.cancel({ name: 'autoDisableSlowMode', data: { channelId } });
+                    }
+                }
+            } catch {
+                return msg.channel.send({ embeds: [failedEmbed('Disable', channelId)] });
+            }
+
+            try {
+                await modLogsChannel.send({
+                    embeds: [modLogEmbed('Disable',
+                        slowModeEmbedField(
+                            author.toString(),
+                            channelId,
+                            'Disabled',
+                            'None',
+                        ),
+                        Colors.Green)],
+                });
+            } catch {
+                msg.channel.send({ embeds: [noChannelEmbed('Disable', 'Mod Log')] });
+            }
+
+            return msg.react('✅');
+        }
+
+        return msg.channel.send({ embeds: [helpEmbed(evokedCommand)] });
+    },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { readdirSync } from 'fs';
 import { join } from 'path';
 import Logger from './lib/logger';
 import { connect } from './lib/db';
+import { setupScheduler } from './lib/scheduler';
 
 dotenv.config();
 require('elastic-apm-node').start({
@@ -46,6 +47,8 @@ client.on('ready', () => {
     // Connect to database
     if (process.env.MONGODB_URL) {
         connect(process.env.MONGODB_URL)
+            .catch(Logger.error);
+        setupScheduler('fbwBotScheduler', process.env.MONGODB_URL)
             .catch(Logger.error);
     }
 });

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -1,0 +1,35 @@
+import Agenda from 'agenda';
+import Logger from './logger';
+import { autoDisableSlowMode } from './scherdulerJobs/autoDisableSlowMode';
+
+let scheduler: Agenda;
+
+export async function setupScheduler(name: string, url: string, callback = Logger.error) {
+    try {
+        scheduler = new Agenda({
+            name,
+            processEvery: '1 minute',
+            db: {
+                address: url,
+                collection: `${name}Jobs`,
+            },
+        });
+        await scheduler.start();
+        scheduler.define('autoDisableSlowMode', autoDisableSlowMode);
+        Logger.info('Scheduler set up');
+    } catch ({ name, message, stack }) {
+        callback({ name, message, stack });
+    }
+
+    scheduler.on('error', (err) => {
+        callback(err);
+    });
+}
+
+export function getScheduler(callback = Logger.error) {
+    if (!scheduler) {
+        callback(new Error('No scheduler available. Check database connection.'));
+        return null;
+    }
+    return scheduler;
+}

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -8,7 +8,8 @@ export async function setupScheduler(name: string, url: string, callback = Logge
     try {
         scheduler = new Agenda({
             name,
-            processEvery: '1 minute',
+            processEvery: '30 seconds',
+            defaultLockLifetime: 30000, // In milliseconds, this makes sure that if the bot restarts with locked jobs, they get released quickly and tried again.
             db: {
                 address: url,
                 collection: `${name}Jobs`,

--- a/src/lib/scherdulerJobs/autoDisableSlowMode.ts
+++ b/src/lib/scherdulerJobs/autoDisableSlowMode.ts
@@ -1,0 +1,79 @@
+import { Job } from 'agenda';
+import { ChannelType, TextChannel, Colors } from 'discord.js';
+import { Channels } from '../../constants';
+import { client } from '../..';
+import { makeEmbed } from '../embed';
+import Logger from '../logger';
+import { getScheduler } from '../scheduler';
+
+const failedEmbed = (action: string, channel: string) => makeEmbed({
+    title: `Slow Message - ${action} failed`,
+    description: `Failed to ${action} the slow mode for channel <#${channel}>.`,
+    color: Colors.Red,
+});
+
+const modLogEmbed = (action: string, fields: any, color: number) => makeEmbed({
+    title: `Slow Mode - ${action}`,
+    fields,
+    color,
+});
+
+export async function autoDisableSlowMode(job: Job) {
+    const scheduler = getScheduler();
+    // Needed because of https://github.com/agenda/agenda/issues/401
+    // eslint-disable-next-line no-underscore-dangle
+    const matchingJobs = await scheduler.jobs({ _id: job.attrs._id });
+    if (matchingJobs.length !== 1) {
+        Logger.debug('Job has been deleted already, skipping execution.');
+        return;
+    }
+    const { channelId } = job.attrs.data;
+    const modLogsChannel = client.channels.resolve(Channels.MOD_LOGS) as TextChannel | null;
+    const slowmodeChannel = client.channels.resolve(channelId);
+    if (!slowmodeChannel || [ChannelType.GuildText, ChannelType.GuildForum, ChannelType.PublicThread, ChannelType.PrivateThread].indexOf(slowmodeChannel.type) === -1) {
+        Logger.error('Slow mode - Auto disable - Unable to disable for non-existing channel');
+        if (modLogsChannel) {
+            await modLogsChannel.send({ embeds: [failedEmbed('Auto disable', channelId)] });
+        }
+        return;
+    }
+    try {
+        if (slowmodeChannel.type === ChannelType.GuildForum || slowmodeChannel.type === ChannelType.GuildText || slowmodeChannel.type === ChannelType.PrivateThread || slowmodeChannel.type === ChannelType.PublicThread) {
+            await slowmodeChannel.setRateLimitPerUser(0, 'Slow mode disabled through bot');
+        }
+        await job.remove();
+    } catch (err) {
+        Logger.error(`Failed to auto disable slow mode for channel <#${channelId}>: ${err}`);
+        return;
+    }
+
+    try {
+        await modLogsChannel.send({
+            embeds: [modLogEmbed('Auto Disable', [
+                {
+                    inline: true,
+                    name: 'Channel',
+                    value: `<#${channelId}>`,
+                },
+                {
+                    inline: true,
+                    name: 'Slow mode limit',
+                    value: 'Disabled',
+                },
+                {
+                    inline: true,
+                    name: 'Auto disable timeout',
+                    value: 'None',
+                },
+                {
+                    inline: true,
+                    name: 'Moderator',
+                    value: 'FBW Bot',
+                },
+            ],
+            Colors.Green)],
+        });
+    } catch (err) {
+        Logger.warn(`Failed to send Mod Log for auto disable of slow mode for channel <#${channelId}>: ${err}`);
+    }
+}


### PR DESCRIPTION
## feat: slowmode with timeout and introducing proper scheduler

## Description

This introduces a few new items:

* A Scheduler based on Agenda (https://github.com/agenda/agenda), which will be used in the future for more than just the slowmode feature (which is why it's a full package with complex functionality, including triggering on bot restart, so schedule is persistent)
* Slow mode command that can:
  * Configure slow mode for a channel, both locally and remotely
  * Configure an auto disable timeout, the bot will automatically disable slow mode again

### Note on persistency

The agenda package uses two variables that come into play with persistency: 

* processEvery - Determines how often the scheduler looks at the database for waiting/open jobs and takes a lock on them. Set here to 30 seconds.
* defaultLockLifetime - How long a lock lasts. Set here to 30 seconds.

When agenda checks every 30 seconds for waiting/open jobs, it will take a lock on and schedule all the jobs that need to be executed within the next 30 seconds. The lock is persisted in the database. 

If the process restarts, it will again look for waiting/open jobs at startup and every 30 seconds. It will not touch jobs that already have a lock because it could be another worker owns that job (it doesn't know if there's multiple schedulers running). However, once it sees that a lock has expired (lock time is older than 30 seconds ago), it will take another lock on that task if it needs to be executed (and likely execute it immediately). 

Because of this logic, it could be that a scheduled job could take up to a minute before it gets executed if the process/bot restarts:

1. Time 0 : Scheduler checks DB for jobs and finds job A that needs to be executed at "Time 30", locks it with "Time 0"
2. Time 28: Bot process restarts
3. Time 29: Scheduler, during bot process start, checks DB for jobs. Job A lock is still valid at this point (29 seconds old). So no lock is taken.
4. Time 30:  Job A is not executed, because it is not in memory.
5. Time 59: Scheduler checks DB for jobs. Job A lock is now expired. Scheduler takes lock on Job A and notices it should have been executed in the past so executes it immediately. 

The current values are picked because:
* The chances a scheduled task needs to run within 30-60 seconds of its creation is small (slowmode disable timer will likely be at least 5 minutes if not longer, other applications won't have that much of granularity either)
* There is no need to more regularly check the DB.

## Test Results

This is a video of the functionality, click the image to get directed to Youtube.
[![FBW Discord Bot - Slowmode with auto disable](https://img.youtube.com/vi/QTsWky1DWrs/0.jpg)](https://youtu.be/QTsWky1DWrs)

## Discord Username

straks#7240
