### PR TITLE
fix: roleinfo showing wrong count because of caching

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## Changelog
 
-Update <small>_ January 2022</small>
+Update <small>_ January 2023</small>
 
-- feat: cacheupdate command to update the bots cache on different server aspects (02/01/2022)
+- fix: roleinfo showing wrong count because of caching (02/01/2023)
+- feat: cacheupdate command to update the bots cache on different server aspects (02/01/2023)
 
 Update <small>_ December 2022</small>
 

--- a/src/commands/utils/roleinfo.ts
+++ b/src/commands/utils/roleinfo.ts
@@ -16,7 +16,7 @@ export const roleinfo: CommandDefinition = {
         }
 
         // Checks the query against the id and checks if the name contains the query
-        await msg.guild.roles.fetch();
+        await msg.guild.members.fetch();
         const rolesCache = msg.guild.roles.cache;
         const role = rolesCache.find((role) => (
             role.name.toLowerCase().includes(query) || role.id === query

--- a/src/commands/utils/roleinfo.ts
+++ b/src/commands/utils/roleinfo.ts
@@ -16,6 +16,7 @@ export const roleinfo: CommandDefinition = {
         }
 
         // Checks the query against the id and checks if the name contains the query
+        await msg.guild.roles.fetch();
         const rolesCache = msg.guild.roles.cache;
         const role = rolesCache.find((role) => (
             role.name.toLowerCase().includes(query) || role.id === query


### PR DESCRIPTION
## fix: roleinfo showing wrong count because of caching

## NOTE

The original PR with fetching the role and updating the cache is not fixing the problem. It just updates the role cache, not the member cache... 

Likely root cause:
* The command gets the size of the collection of members on a Role
* The collection of members on a role is based on the members known in the cache that have that role
* Members are only added to the cache if the bot has interacted with them and handled a command from them (or perhaps has seen a message from them) since its last start.

So for all members that haven't been actively online, the member information (including roles) has not been added to the cache and so they are not part of the cached collection.

## Description

roleinfo is giving the wrong counts 
<img width="311" alt="Screen Shot 2023-01-01 at 9 54 09 PM" src="https://user-images.githubusercontent.com/942391/210184313-82e722f5-e2ec-4985-b844-0e45d1561831.png">
VS
<img width="487" alt="Screen Shot 2023-01-01 at 9 55 08 PM" src="https://user-images.githubusercontent.com/942391/210184337-95884b86-f12d-487e-a934-89d63c231079.png">

Initial thoughts are that this is a caching issue as the cache isn't refreshed when the command is executed. So there might be a weird state in the cache in terms of numbers. 

It seems to happen more in large roles (lots of members) and not small groups. So it is hard to reproduce in small scale servers to fix.

As all the other calls with trying to find something and handling the role are all done on the cache and not async (no Promises), the cache is the most likely culprit. This change forces a cache update. 

## Test Results
Screenshot where in between a member was removed from a group on a test server. Not able to reproduce the issue on my test server. This is more to proof that the change doesn't break anything. 

<img width="344" alt="Screen Shot 2023-01-01 at 9 58 25 PM" src="https://user-images.githubusercontent.com/942391/210184393-0d267995-8e24-47ef-a760-d910e0fe9b57.png">

## Discord Username
straks#7240
