### PR TITLE
feat: cacheupdate command to update the bots cache on different server aspects

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+Update <small>_ January 2022</small>
+
+- feat: cacheupdate command to update the bots cache on different server aspects (02/01/2022)
+
 Update <small>_ December 2022</small>
 
 - fix: manualleg image of the doc site and add alias (26/12/2022)

--- a/.github/command-docs.md
+++ b/.github/command-docs.md
@@ -170,6 +170,7 @@
 | Command               | Description                                                                                             | Alias                                      |
 |:----------------------|:--------------------------------------------------------------------------------------------------------|:-------------------------------------------|
 | .ban                  | ---                                                                                                     | ---                                        |
+| .cacheupdate          | Update the cache of the bot with the information from discord for different aspects                     | .cache-update                              |
 | .deletewarn           | Deletes a users warning                                                                                 | .delwarn <br/> .deletewarning              |
 | .faq                  | Sends the FAQ                                                                                           | ---                                        |
 | .roleassignment       | Sends the role assignment messages                                                                      | ---                                        |

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -156,6 +156,7 @@ import { winss } from './support/winss';
 import { simbridgeLog } from './support/simbridgeLog';
 import { sticky } from './moderation/sticky';
 import { navRouteTypes } from './general/navRouteTypes';
+import { cacheUpdate } from './moderation/cacheUpdate';
 
 const commands: BaseCommandDefinition[] = [
     typeCommand,
@@ -314,6 +315,7 @@ const commands: BaseCommandDefinition[] = [
     simbridgeLog,
     sticky,
     navRouteTypes,
+    cacheUpdate,
 ];
 
 const commandsObject: { [k: string]: BaseCommandDefinition } = {};


### PR DESCRIPTION
## feat: cacheupdate command to update the bots cache on different server aspects

## Description

In certain situations it could be useful to force a cache update of the bot. (look at issue #395 for instance). This command allows the most typical caches to be updated fully.

## Test Results

<img width="379" alt="Screen Shot 2023-01-02 at 12 35 24 AM" src="https://user-images.githubusercontent.com/942391/210187618-3eea713b-7126-4f2d-bfc4-c0295ec6a92f.png">
<img width="306" alt="Screen Shot 2023-01-02 at 12 35 34 AM" src="https://user-images.githubusercontent.com/942391/210187623-9e71a75e-cb08-4e0f-a718-337f9a1ccfb9.png">

## Discord Username

straks#7240
