### PR TITLE
feat: Adding issue templates and accompanying command

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ January 2023</small>
 
+- feat: Github issues templates and accompanying command (02/01/2023)
 - fix: roleinfo showing wrong count because of caching (02/01/2023)
 - feat: cacheupdate command to update the bots cache on different server aspects (02/01/2023)
 

--- a/.github/ISSUE_TEMPLATE/bug_report_beta.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_beta.yaml
@@ -1,0 +1,66 @@
+name: Bug Report
+description: File a bug report
+labels: [Bug]
+body:
+- type: markdown
+  attributes:
+    value: "# FlyByWire Discord bot Bug Report Form"
+- type: dropdown
+  id: type
+  attributes:
+    label: Bug type
+    description: What type of feature would this be?
+    options:
+    - Wrong data or information
+    - Moderation functionality issue
+    - Utility or complex functionality issue
+  validations:
+    required: true
+- type: textarea
+  id: desc
+  attributes:
+    label: Describe the bug
+    description: A clear and concise description of what the bug is and what happened.
+  validations:
+    required: true
+- type: textarea
+  id: expected
+  attributes:
+    label: Expected behavior
+    description: A clear and concise description of what you expected to happen.
+  validations:
+    required: true
+- type: textarea
+  id: reproduce
+  attributes:
+    label: Steps to reproduce
+    placeholder: |
+      1.
+      2.
+      3.
+      ...
+    description: We need to know how you encountered the bug to properly troubleshoot the issue.
+  validations:
+    required: true
+- type: textarea
+  id: references
+  attributes:
+    label: References (optional)
+    description: If applicable, add screenshots or videos to help explain your problem.
+  validations:
+    required: false
+- type: textarea
+  id: misc
+  attributes:
+    label: Additional info (optional)
+    description: Add any other context about the problem here. Was this working before? When did the issue start occurring?
+  validations:
+    required: false
+- type: input
+  id: discord
+  attributes:
+    label: Discord Username (optional)
+    description: You may optionally provide your discord username, so that we may contact you directly about the issue.
+    placeholder: ex. username#1234
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: FBW Bot channel on Discord
+    url: https://discord.com/channels/738864299392630914/897491699167793182
+    about: Discuss the FBW Discord bot on its own Discord Channel

--- a/.github/ISSUE_TEMPLATE/feature_request_beta.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request_beta.yaml
@@ -1,0 +1,49 @@
+name: Feature Request
+description: Suggest a new feature for the FlyByWire Discord bot
+labels: [Request]
+body:
+- type: markdown
+  attributes:
+    value: "# FBW Discord Bot Feature Request Form"
+- type: dropdown
+  id: type
+  attributes:
+    label: Feature type
+    description: What type of feature would this be?
+    options:
+    - Aircraft information
+    - Support information
+    - General information
+    - Moderation feature
+    - Utility or complex functionality
+  validations:
+    required: true
+- type: textarea
+  id: desc
+  attributes:
+    label: Description
+    description: Describe the feature you'd like to see implemented. Is your feature request related to a problem?
+  validations:
+    required: true
+- type: textarea
+  id: references
+  attributes:
+    label: References (optional)
+    description: If applicable, add screenshots or videos to help explain your request.
+  validations:
+    required: false
+- type: textarea
+  id: misc
+  attributes:
+    label: Additional info (optional)
+    description: Add any other context about the feature request here.
+  validations:
+    required: false
+- type: input
+  id: discord
+  attributes:
+    label: Discord Username (optional)
+    description: You may optionally provide your discord username, so that we may contact you directly about the issue.
+    placeholder: ex. username#1234
+  validations:
+    required: false

--- a/.github/command-docs.md
+++ b/.github/command-docs.md
@@ -91,29 +91,30 @@
 
 ### General
 
-| Command           | Description                                                                                                             | Alias                               |
-|:------------------|:------------------------------------------------------------------------------------------------------------------------|:------------------------------------|
-| .dfd              | Provides link to Digital Flight Dynamics discord server                                                                 | ---                                 |
-| .docsearch        | Provides a link to the FlyByWire documentation, either a general link, or a link for a specific search                  | .documentation <br> .docs <br> .doc |
-| .donate           | Provides a link to the open collective                                                                                  | ---                                 |
-| .goldenrules      | Provides an image describing the golden rules an Airbus pilot should follow                                             | .golden <br> .gr                    |
-| .fsltl            | Provides link to the FS Live Traffic Liveries Discord server                                                            | .fslivetrafficliveries              |
-| .headwind         | Provides link to the Headwind Discord server                                                                            | .hw                                 |
-| .installer        | Provides link to the new installer                                                                                      | ---                                 |
-| .latlong          | Provides a cheat sheet for conversion between Latitude and longitude coordinates between short and long format          | .llfix                              |
-| .msfsdisc         | Provides link to Microsoft Flight Simulator discord server                                                              | .fsdisc <br> .msfsdiscord           |
-| .notams           | Links to the FlyByWire Simulations NOTAMS                                                                               | .notam <br> .news                   |
-| .qa               | Links to the Quality Assurance docs page                                                                                | ---                                 |
-| .roadmap          | FBW Roadmap                                                                                                             | .goals                              |
-| .salty            | Provides link to salty discord server                                                                                   | .sal <br> .ninjo                    |
-| .synaptic         | Provides link to synaptic discord server                                                                                | .syn                                |
-| .temporarycommand | Runs a temporary command created by the Moderators and can list them. These are temporary commands for simple messages. | .tempcommand <br> .tc               |
-| .translate        | Provides information on how to contribute to various FlyByWire translation efforts                                      | ---                                 |
-| .website          | Provides a link to the FlyByWire Simulations website                                                                    | .web                                |
-| .when             | Explain the absence of release dates or ETAs                                                                            | ---                                 |
-| .thumb            | Answers the big question, will it have FEATURE?                                                                         | .willithave                         |
-| .xbox             | Short response + link to NOTAM for xbox marketplace                                                                     | .xboxmarketplace                    |
-| .yourcontrols     | Provides link to the YourControls discord                                                                               | .yc                                 |
+| Command           | Description                                                                                                             | Alias                                                       |
+|:------------------|:------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------|
+| .botissue         | Provides details on where to create a FBW Discord Bot Issue or Feature Request                                          | .bot-issue <br> .botfeature <br> .bot-feature <br> .botfeat |
+| .dfd              | Provides link to Digital Flight Dynamics discord server                                                                 | ---                                                         |
+| .docsearch        | Provides a link to the FlyByWire documentation, either a general link, or a link for a specific search                  | .documentation <br> .docs <br> .doc                         |
+| .donate           | Provides a link to the open collective                                                                                  | ---                                                         |
+| .goldenrules      | Provides an image describing the golden rules an Airbus pilot should follow                                             | .golden <br> .gr                                            |
+| .fsltl            | Provides link to the FS Live Traffic Liveries Discord server                                                            | .fslivetrafficliveries                                      |
+| .headwind         | Provides link to the Headwind Discord server                                                                            | .hw                                                         |
+| .installer        | Provides link to the new installer                                                                                      | ---                                                         |
+| .latlong          | Provides a cheat sheet for conversion between Latitude and longitude coordinates between short and long format          | .llfix                                                      |
+| .msfsdisc         | Provides link to Microsoft Flight Simulator discord server                                                              | .fsdisc <br> .msfsdiscord                                   |
+| .notams           | Links to the FlyByWire Simulations NOTAMS                                                                               | .notam <br> .news                                           |
+| .qa               | Links to the Quality Assurance docs page                                                                                | ---                                                         |
+| .roadmap          | FBW Roadmap                                                                                                             | .goals                                                      |
+| .salty            | Provides link to salty discord server                                                                                   | .sal <br> .ninjo                                            |
+| .synaptic         | Provides link to synaptic discord server                                                                                | .syn                                                        |
+| .temporarycommand | Runs a temporary command created by the Moderators and can list them. These are temporary commands for simple messages. | .tempcommand <br> .tc                                       |
+| .translate        | Provides information on how to contribute to various FlyByWire translation efforts                                      | ---                                                         |
+| .website          | Provides a link to the FlyByWire Simulations website                                                                    | .web                                                        |
+| .when             | Explain the absence of release dates or ETAs                                                                            | ---                                                         |
+| .thumb            | Answers the big question, will it have FEATURE?                                                                         | .willithave                                                 |
+| .xbox             | Short response + link to NOTAM for xbox marketplace                                                                     | .xboxmarketplace                                            |
+| .yourcontrols     | Provides link to the YourControls discord                                                                               | .yc                                                         |
 
 ### Utilities
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -157,6 +157,7 @@ import { simbridgeLog } from './support/simbridgeLog';
 import { sticky } from './moderation/sticky';
 import { navRouteTypes } from './general/navRouteTypes';
 import { cacheUpdate } from './moderation/cacheUpdate';
+import { botIssue } from './support/botIssue';
 
 const commands: BaseCommandDefinition[] = [
     typeCommand,
@@ -316,6 +317,7 @@ const commands: BaseCommandDefinition[] = [
     sticky,
     navRouteTypes,
     cacheUpdate,
+    botIssue,
 ];
 
 const commandsObject: { [k: string]: BaseCommandDefinition } = {};

--- a/src/commands/support/botIssue.ts
+++ b/src/commands/support/botIssue.ts
@@ -1,0 +1,15 @@
+import { MessageCommandDefinition } from '../../lib/command';
+import { makeEmbed } from '../../lib/embed';
+import { CommandCategory } from '../../constants';
+
+const genericBotIssueEmbed = makeEmbed({
+    title: 'FlyByWire Discord Bot | Opening an Issue of Feature request',
+    description: 'You can open an issue or feature request for the FlyByWire Discord Bot using [this link](https://github.com/flybywiresim/discord-bot/issues/new/choose).',
+});
+
+export const botIssue: MessageCommandDefinition = {
+    name: ['botissue', 'bot-issue', 'botfeature', 'bot-feature', 'botfeat'],
+    category: CommandCategory.SUPPORT,
+    description: 'Provides details on where to create a FBW Discord Bot Issue or Feature Request.',
+    genericEmbed: genericBotIssueEmbed,
+};


### PR DESCRIPTION
## feat: Adding issue templates and accompanying command

## Description

Adds two issue types that can be created on the repo for tracking bugs and feature requests.

Also provides the command to link to creating a new issue/feature request for the bot. 

## Test Results

<img width="1235" alt="Screen Shot 2023-01-02 at 2 26 24 PM" src="https://user-images.githubusercontent.com/942391/210239081-769a7c7a-e0d1-4ef4-84fd-6053773b900a.png">
<img width="965" alt="Screen Shot 2023-01-02 at 2 26 40 PM" src="https://user-images.githubusercontent.com/942391/210239087-b03f5c13-ac36-42e6-967b-784c080c3623.png">
<img width="956" alt="Screen Shot 2023-01-02 at 2 26 57 PM" src="https://user-images.githubusercontent.com/942391/210239095-251d0432-805c-4161-a1d8-170545b757d5.png">
<img width="532" alt="Screen Shot 2023-01-02 at 2 37 29 PM" src="https://user-images.githubusercontent.com/942391/210239097-2fc81199-7ff7-42dd-b609-c35b018aa4fe.png">


## Discord Username

straks#7240


