### PR TITLE
feat: navigraph discord link

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ January 2023</small>
 
+- feat: navigraph discord link, requires a small change in navigraphNavdata command (02/01/2023)
 - fix: roleinfo showing wrong count because of caching (02/01/2023)
 - feat: cacheupdate command to update the bots cache on different server aspects (02/01/2023)
 

--- a/.github/command-docs.md
+++ b/.github/command-docs.md
@@ -76,7 +76,7 @@
 | .market         | Help with removing the marketplace version                                        | .marketremove <br> .removemarket <br> .rm <br> .mr |
 | .msfs           | Provides links to MSFS support for sim issues                                     | .msfsforum                                         |
 | .navdata        | Explains the use of navdata by the FlyByWire A32NX and how to check its accuracy  | ---                                                |
-| .navigraph      | Provides help with Navigraph navdata reinstall                                    | .navigraphnavdata                                  |
+| .navigraphdata  | Provides help with Navigraph NavData reinstall                                    | .navigraphnavdata                                  |
 | .reportedissues | Provides a link to the reported issues page within docs                           | .issues                                            |
 | .screenshot     | Help to screenshot for support                                                    | .cockpit <br> .ss                                  |
 | .simbridgelog   | Information on how to provide SimBridge Log                                       | .slog                                              |
@@ -102,6 +102,7 @@
 | .installer        | Provides link to the new installer                                                                                      | ---                                 |
 | .latlong          | Provides a cheat sheet for conversion between Latitude and longitude coordinates between short and long format          | .llfix                              |
 | .msfsdisc         | Provides link to Microsoft Flight Simulator discord server                                                              | .fsdisc <br> .msfsdiscord           |
+| .navigraph        | Provides link to Navigraph discord server                                                                               | ---                                 |
 | .notams           | Links to the FlyByWire Simulations NOTAMS                                                                               | .notam <br> .news                   |
 | .qa               | Links to the Quality Assurance docs page                                                                                | ---                                 |
 | .roadmap          | FBW Roadmap                                                                                                             | .goals                              |

--- a/src/commands/general/navigraph.ts
+++ b/src/commands/general/navigraph.ts
@@ -1,0 +1,9 @@
+import { CommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+
+export const navigraph: CommandDefinition = {
+    name: ['navigraph'],
+    description: 'Provides link to the Navigraph Discord server',
+    category: CommandCategory.GENERAL,
+    executor: (msg) => msg.channel.send('https://discord.gg/navigraph'),
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -157,6 +157,7 @@ import { simbridgeLog } from './support/simbridgeLog';
 import { sticky } from './moderation/sticky';
 import { navRouteTypes } from './general/navRouteTypes';
 import { cacheUpdate } from './moderation/cacheUpdate';
+import { navigraph } from './general/navigraph';
 
 const commands: BaseCommandDefinition[] = [
     typeCommand,
@@ -316,6 +317,7 @@ const commands: BaseCommandDefinition[] = [
     sticky,
     navRouteTypes,
     cacheUpdate,
+    navigraph,
 ];
 
 const commandsObject: { [k: string]: BaseCommandDefinition } = {};

--- a/src/commands/support/navigraphNavdata.ts
+++ b/src/commands/support/navigraphNavdata.ts
@@ -5,7 +5,7 @@ import { makeEmbed, makeLines } from '../../lib/embed';
 const NAVIGRAPH_NAVDATA_URL = 'https://cdn.discordapp.com/attachments/785976111875751956/912394143844696154/unknown.png';
 
 export const navigraphNavdata: CommandDefinition = {
-    name: ['navigraph', 'navigraphdata'],
+    name: ['navigraphdata', 'navigraphnavdata'],
     description: 'Provides help with Navigraph navdata reinstall',
     category: CommandCategory.SUPPORT,
     executor: (msg) => {


### PR DESCRIPTION
## feat: navigraph discord link

## Description

Simple link to the Navigraph Discord server... Had to rename the navigraph data command though. 

Reference: https://github.com/flybywiresim/discord-bot/projects/1#card-86854395

## Test Results

<img width="506" alt="Screen Shot 2023-01-02 at 3 10 45 PM" src="https://user-images.githubusercontent.com/942391/210243236-b03e7406-8354-489f-b5a4-5e1b22517f08.png">

## Discord Username

straks#7240