### PR TITLE
refactor: update and fix various commands

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 Update <small>_ March 2023</small>
 
+- refactor: update and fix various commands (04/03/2023)
 - refactor: update existing command permissions (04/03/2023)
 
 Update <small>_ February 2023</small>
 
-- refactor: update and fix various commands (23/02/2023)
 - fix: update report channel for experimental (22/02/2023)
 - feat: Add GSX Integration command (22/02/2023)
 - feat: feat: unified command permissions framework (09/02/2023)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ February 2023</small>
 
+- refactor: update and fix various commands (23/02/2023)
 - fix: update report channel for experimental (22/02/2023)
 - feat: Add GSX Integration command (22/02/2023)
 - feat: feat: unified command permissions framework (09/02/2023)

--- a/src/commands/aircraft/airframe.ts
+++ b/src/commands/aircraft/airframe.ts
@@ -9,7 +9,7 @@ const genericAirframeEmbed = makeEmbed({
 
 const a32nxAirframeEmbed = makeEmbed({
     title: 'FlyByWire A32NX | simBrief Airframe',
-    description: 'Our updated simBrief airframe for the A32NX with correct weights is available [here](https://docs.flybywiresim.com/fbw-a32nx/installation/#simbrief-airframe). This is a new airframe based on our updated flight model, and will always be kept up-to-date.',
+    description: 'Our updated simBrief airframe for the A32NX with correct weights is available [here](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/simbrief/#simbrief-airframe). This is a new airframe based on our updated flight model, and will always be kept up-to-date.',
 });
 
 const a380xAirframeEmbed = makeEmbed({

--- a/src/commands/aircraft/atc.ts
+++ b/src/commands/aircraft/atc.ts
@@ -23,7 +23,7 @@ const genericAtcEmbed = makeEmbed({
         },
         {
             name: 'More information',
-            value: 'Please read the [Flight Planning guide](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flight-planning/) for more details.',
+            value: 'Please read the [Flight Planning Guide](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flight-planning/) for more details.',
             inline: false,
         },
     ],

--- a/src/commands/aircraft/experimental.ts
+++ b/src/commands/aircraft/experimental.ts
@@ -5,7 +5,7 @@ import { makeEmbed, makeLines } from '../../lib/embed';
 const experimentalEmbed = makeEmbed({
     title: 'FlyByWire A32NX | Experimental Version',
     description: makeLines([
-        'Currently experimental is geared toward testing the initial version of VNAV and flyPadOS3. Please see our [Experimental Version Support Page](https://docs.flybywiresim.com/fbw-a32nx/support/exp/) for more information. **Do not expect support for the experimental version - use at own risk!**',
+        'Currently, experimental is geared toward testing the initial version of VNAV with additional features added at the development team\'s discretion. Please see our [Experimental Version Support Page](https://docs.flybywiresim.com/exp/) for more information. **Do not expect support for the experimental version - use at own risk!**',
         '',
         'Please use the appropriate discord channel or forum to discuss any issues:',
         `<#${Channels.EXP_CFMS_ISSUES}>`,

--- a/src/commands/aircraft/flyPadOS.ts
+++ b/src/commands/aircraft/flyPadOS.ts
@@ -25,8 +25,6 @@ export const flyPadOS: CommandDefinition = {
                 '- [Interior Lighting and Aircraft Presets](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/presets/)',
                 '- [Settings](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/settings/)',
                 '- [Throttle Calibration](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/throttle-calibration/)',
-                '',
-                'See the [flyPadOS 2 documentation](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados2/) for the older version of flyPadOS.',
             ]),
         });
 

--- a/src/commands/support/reportedissues.ts
+++ b/src/commands/support/reportedissues.ts
@@ -9,7 +9,7 @@ export const reportedissues: CommandDefinition = {
     executor: (msg) => {
         const reportedissuesEmbed = makeEmbed({
             title: 'FlyByWire A32NX | Reported Issues',
-            description: 'Please see [this link](https://docs.flybywiresim.com/start/reported-issues/) for a current list of reported issues.',
+            description: 'Please see [this link](https://docs.flybywiresim.com/fbw-a32nx/support/reported-issues/) for a current list of reported issues.',
         });
 
         return msg.channel.send({ embeds: [reportedissuesEmbed] });

--- a/src/commands/support/reportedissues.ts
+++ b/src/commands/support/reportedissues.ts
@@ -9,7 +9,7 @@ export const reportedissues: CommandDefinition = {
     executor: (msg) => {
         const reportedissuesEmbed = makeEmbed({
             title: 'FlyByWire A32NX | Reported Issues',
-            description: 'Please see [this link](https://docs.flybywiresim.com/fbw-a32nx/support/reported-issues/) for a current list of reported issues.',
+            description: 'Please see [this link](https://docs.flybywiresim.com/reported-issues/) for a current list of reported issues.',
         });
 
         return msg.channel.send({ embeds: [reportedissuesEmbed] });


### PR DESCRIPTION
## Description

Updates copy of various commands and fixes broken links:

### Updated Commands List

- exp
  - update the copy to be more general with VNAV as the main mention
  - update URL to `/exp` in case the page is ever moved or restructured at a later time (internal redirect on docs site)
- airframe
  - update the docs URL to its new location to prevent more clicks
- reported-issues
  - Since this is our project might as well have it correct + up2date and using the newer `/reported-issues` internal redirect. Same reasoning as the exp command in the case page is ever moved or restructured at a later time.
- atc
  - Minor capitalization fix
- flypadOS
  - Remove links to flyPadOS 2. Documentation no longer exists and the version is deprecated

## Test Results
Links were tested and all working

<img width="706" alt="Screenshot 2023-02-23 at 12 12 36 PM" src="https://user-images.githubusercontent.com/1619968/220864910-0fa3c950-6249-4bdd-96a5-0947a985f672.png">
<img width="795" alt="Screenshot 2023-02-23 at 12 12 30 PM" src="https://user-images.githubusercontent.com/1619968/220864922-d1652954-dbbe-4306-a806-f7ecf5675b57.png">


## Discord Username

Valastiri#8902