### PR TITLE
fix: adds date to warn doc for timeouts

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ March 2023</small>
 
+- fix: adds date to warn doc for timeout (15/03/2023)
 - feat: Show specific section link for reported issues command (12/03/2023)
 - feat: reply to question or command message (11/03/2023)
 - refactor: use downscaled gifs for efb and pov (11/03/2023)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Update <small>_ March 2023</small>
 
-- fix: adds date to warn doc for timeout (15/03/2023)
+- fix: adds date to warn doc for timeout (25/03/2023)
 - feat: Show specific section link for reported issues command (12/03/2023)
 - feat: reply to question or command message (11/03/2023)
 - refactor: use downscaled gifs for efb and pov (11/03/2023)

--- a/src/commands/moderation/timeout.ts
+++ b/src/commands/moderation/timeout.ts
@@ -170,7 +170,7 @@ export const timeout: CommandDefinition = {
         const timeoutArg = args[1];
         const reason = args.slice(2).join(' ');
         const currentDate = new Date();
-        const formattedDate: string = moment(currentDate).utcOffset(0).format('YYYY-MM-DDTHH:mm:ss');
+        const formattedDate: string = moment(currentDate).utcOffset(0).format('DD, MM, YYYY, HH:mm:ss');
 
         let timeoutDuration: number;
         switch (timeoutArg[timeoutArg.length - 1].toLowerCase()) {
@@ -258,6 +258,7 @@ export const timeout: CommandDefinition = {
                     userID,
                     moderator,
                     reason: `*This user was timed out because:* ${reason}`,
+                    date: currentDate,
                 });
 
                 try {


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description

Adds the date to the warn doc for timeouts - this was missed when initially adding functionality.

The date format has also been changed to match other mod log entries.

<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results

Before - These were all created apart from each other - see the time is the same as when command is called:

![image](https://user-images.githubusercontent.com/67422707/224733568-681da474-73f0-457a-ba22-fcd4aead9971.png)

After - See the last two, although close, they are different and are not the same as the command call time:

![image](https://user-images.githubusercontent.com/67422707/224734285-25fd20ae-9e22-4c22-a7e3-33f4651eda2d.png)

<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username

BenW#8484

<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
