### PR TITLE
fix: birthday handler random delays bug

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ March 2023</small>
 
+- fix: birthday handler proper handling of connections and improvements (25/03/2023)
 - fix: add link for support channel to sg (25/03/2023)
 - feat: Add support Guide command (25/03/2023)
 - feat: add reply functionality for complex commands (25/03/2023)


### PR DESCRIPTION
## fix: birthday handler random delays bug

## Description

* moved fetching of birthdays after DB conn check to fix bug. Before the
  fetch of birthdays could happen without DB conn present which would
  return an empty list. This could happen if the db connection had timed
  out. Which meant the BDs were just never fetched until there happened
  to be an already active DB conn.
* Cleaned up comments, logging and collapsed new lines for readability
  improvements
* Included logging for every execution, to better keep track of handler
  execution
* Changed execution to every 30 minutes instead of once an hour to get
  the birthday message closer to the preferred time

## Test Results

Tested by setting runtime to 1 minute and executing it with multiple birthdays. Bug testing is more difficult as it needs DB timeout to happen, but logic is solid.

## Discord Username

straks#7240
