### PR TITLE
fix: grammar and hyperlink in embed for utf-8.ts

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Update <small>_ April 2023</small>
 
-- fix: grammar and hyperlink in embed for utf-8.ts
+- fix: grammar and hyperlink in embed for utf-8.ts (17/04/2023)
 - feat: add more specific text for the general troubleshooting steps and link to simbridge in the reportes issues and help commands (17/04/2023)
 - feat: Add tca command for tca airbus edition issues (16/04/2023)
 - chore: bump mongoose to version 7.0.3 (13/04/2023)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ April 2023</small>
 
+- fix: grammar and hyperlink in embed for utf-8.ts
 - feat: add more specific text for the general troubleshooting steps and link to simbridge in the reportes issues and help commands (17/04/2023)
 - feat: Add tca command for tca airbus edition issues (16/04/2023)
 - chore: bump mongoose to version 7.0.3 (13/04/2023)

--- a/src/commands/support/utf-8.ts
+++ b/src/commands/support/utf-8.ts
@@ -7,7 +7,7 @@ const UTF8_HELP_URL = `${imageBaseUrl}/support/utf-8.PNG`;
 const utf8Embed = makeEmbed({
     title: 'FlyByWire A32NX | UTF-8',
     description: makeLines([
-        'Some users experience problems with various system in the A32NX. These are caused by an issue within MSFS which requires the use of the UTF-8 Region setting in Windows.',
+        'Some users experience problems with various systems in the A32NX. These are caused by an issue within MSFS which requires the use of the UTF-8 Region setting in Windows.',
         '',
         'To enable UTF-8 support follow the steps below:',
         '',

--- a/src/commands/support/utf-8.ts
+++ b/src/commands/support/utf-8.ts
@@ -19,7 +19,7 @@ const utf8Embed = makeEmbed({
         '',
         '• Click OK and restart your computer.',
         '',
-        'Please see our [documentation](https://docs.flybywiresim.com/fbw-a32nx/settings/#utf8-support) for more information.',
+        'Please see our [documentation](https://docs.flybywiresim.com/fbw-a32nx/settings/#utf-8-support) for more information.',
     ]),
     image: { url: UTF8_HELP_URL },
 });


### PR DESCRIPTION
## General grammar fix

## Description

Adds an 's' to various system(s).

This is in addition to Beheh's PR #444 to fix the link as well.

## Test Results

<img width="613" alt="image" src="https://user-images.githubusercontent.com/1619968/232561222-f73b09ab-e9fc-4c03-94e6-1eba186e546e.png">


## Discord Username

Valastiri#8902
