### PR TITLE
feat: prevent changelog verification on fork

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ May 2023</small>
 
+- ci: prevent changelog verification on fork (15/05/2023)
 - feat: add command to check last simbrief flightplan (08/05/2023)
 - feat: don't delete nohello with additional content (01/05/2023)
 

--- a/.github/workflows/verify-changelog.yml
+++ b/.github/workflows/verify-changelog.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.draft == false && github.repository_owner == 'flybywiresim' }} # Prevent running on forks
     steps:
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description

Prevents the changelog verifier workflow from running on forks and when the pr is still a draft. (copied from the docs repo)
Changelog still has to be provided before merging, except with the no changelog tag.


## Test Results

![image](https://github.com/flybywiresim/discord-bot/assets/79196358/ee4061e6-4229-4208-9945-8fd43d2a5330)
![image](https://github.com/flybywiresim/discord-bot/assets/79196358/7513f626-15e7-4276-8df0-c761506ff617)


## Discord Username
Slein#8982