### PR TITLE
fix: ping in delete warning mod log

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ May 2023</small>
 
+- fix: ping in delete warning mod log (16/05/2023)
 - refactor: update versions links (15/05/2023)
 - feat: add airac cycle to simbriefdata (12/05/2023)
 - feat: add command to check last simbrief flightplan (08/05/2023)

--- a/src/commands/moderation/warn/deleteWarn.ts
+++ b/src/commands/moderation/warn/deleteWarn.ts
@@ -84,7 +84,7 @@ export const deleteWarn: CommandDefinition = {
 
         const modLogsEmbed = makeEmbed({
             title: 'Warn - Removed',
-            description: `A warning has been remove by <@${msg.author}>`,
+            description: `A warning has been remove by ${msg.author}`,
             fields,
             color: Colors.Green,
         });


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description

Fixes the ping in the mod log for warning deletes.

<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results

Top: Before
Bottom: Fix

![image](https://github.com/flybywiresim/discord-bot/assets/67422707/d9ee2b42-7540-4541-8f48-3b345c5a5418)

<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username

BenW#8484

<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
