### PR TITLE
fix: typo in holds

### DIFF
--- a/src/commands/aircraft/holds.ts
+++ b/src/commands/aircraft/holds.ts
@@ -4,7 +4,7 @@ import { makeEmbed } from '../../lib/embed';
 
 const holdsEmbed = makeEmbed({
     title: 'FlyByWire A32NX | Holds documentation',
-    description: 'Please see our [Holds documentation](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-planning/holds/) for information about holds and how to configures them on the FlyByWire A32NX.',
+    description: 'Please see our [Holds documentation](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-planning/holds/) for information about holds and how to configure them on the FlyByWire A32NX.',
 });
 
 export const holds: MessageCommandDefinition = {


### PR DESCRIPTION
<!-- ## Title -->

## Description
Fixed a typo in the .holds command, where a word was in plural, when it shouldn't be

## Test Results
Fixed just one letter, didn't test

## Discord Username
Lauvaan#3330