### PR TITLE
fix: remove exclamation mark in .build

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 Update <small>_ July 2023</small>
 
-- feat: added .devLanguages to confirm languages used in A32NX.
+- fix: removed an exclamation mark from the build/build info command, as per contributing guidelines 03.07.2023)
+- feat: added .devLanguages to confirm languages used in A32NX. (02.07.20223)
 
 Update <small>_ June 2023</small>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Update <small>_ July 2023</small>
 
-- fix: removed an exclamation mark from the build/build info command, as per contributing guidelines 03.07.2023)
+- fix: removed an exclamation mark from the build/build info command, as per contributing guidelines (03.07.2023)
 - feat: added .devLanguages to confirm languages used in A32NX. (02.07.20223)
 
 Update <small>_ June 2023</small>

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 Update <small>_ July 2023</small>
 
-- fix: removed an exclamation mark from the build/build info command, as per contributing guidelines (03.07.2023)
-- feat: added .devLanguages to confirm languages used in A32NX. (02.07.20223)
+- fix: removed an exclamation mark from the build/build info command, as per contributing guidelines (04/07/2023)
+- feat: added .devLanguages to confirm languages used in A32NX (02/07/2023)
 
 Update <small>_ June 2023</small>
 

--- a/src/commands/support/build.ts
+++ b/src/commands/support/build.ts
@@ -5,7 +5,7 @@ import { makeEmbed, makeLines } from '../../lib/embed';
 const buildEmbed = makeEmbed({
     title: 'FlyByWire Support | Build Info',
     description: makeLines([
-        'Please send us your build info!',
+        'Please send us your build info.',
         '',
         'Navigate to your Community folder and open the following A32NX file with Notepad:',
         '',


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description

<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->
Removed an exclamation mark from .build command, as that isn't a warning, and as per contributing guidelines, exclamation marks shouldn't be used, if it isn't a warning.

## Test Results

<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username

<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
