### PR TITLE
feat: Adding protection if parsing channels or roles fail and autodelete command

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ July 2023</small>
 
+- fix: adding protection if parsing channels or roles fail and autodelete command (08/07/2023)
 - fix: adding channel based permissions for memes and some utils (08/07/2023)
 - feat: rules updated (05/07/2023)
 - fix: removed an exclamation mark from the build/build info command, as per contributing guidelines (04/07/2023)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Update <small>_ July 2023</small>
 
-- fix: adding protection if parsing channels or roles fail and autodelete command (08/07/2023)
+- fix: adding protection if parsing channels or roles fail and autodelete command (09/07/2023)
 - fix: adding channel based permissions for memes and some utils (08/07/2023)
 - feat: rules updated (05/07/2023)
 - fix: removed an exclamation mark from the build/build info command, as per contributing guidelines (04/07/2023)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -91,7 +91,7 @@ export const AircraftTypeList = {
     a380x: '38:1044695718348210177',
 };
 
-export const PermissionsEmbedDelay = 10000;
+export const PermissionsEmbedDelay = 15000;
 
 // imageBaseUrl - Below takes the IMAGE_BASE_URL entry from the `env` and strips the trailing `/` if present
 


### PR DESCRIPTION
## Adding protection if parsing channels or roles fail and autodelete command

## Description

Before, if verbose errors were enabled and the constants.ts did not have the correct IDs, the bot would crash. This adds a protection and fallback to the default error message.

It also autodeletes the command itself, not just the error message.

And to clarify to the user, it mentions in the error message that it will be autodeleted after the configured time (if configured, which it should be)

## Test Results

<img width="414" alt="Screenshot 2023-07-08 at 12 29 23 PM" src="https://github.com/flybywiresim/discord-bot/assets/942391/83ccb9d5-7812-4f8f-a145-76128e96b977">

<img width="436" alt="Screenshot 2023-07-08 at 12 32 58 PM" src="https://github.com/flybywiresim/discord-bot/assets/942391/93c99197-7cb3-4716-b1cf-a4eec53ee1d3">

## Discord Username

straks
