### PR TITLE
feat: Optimize simbriefdata for input error

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ July 2023</small>
 
+- feat: optimize simbriefdata for input error and check for FBW airframe (11/07/2023)
 - fix: adding protection if parsing channels or roles fail and autodelete command (09/07/2023)
 - fix: adding channel based permissions for memes and some utils (08/07/2023)
 - feat: rules updated (05/07/2023)

--- a/src/commands/utils/simbriefdata.ts
+++ b/src/commands/utils/simbriefdata.ts
@@ -49,6 +49,7 @@ const pilotIdNotReplacedEmbed = makeEmbed({
     description: makeLines([
         'Please replace the *<pilotId>* in the used command with your simbrief pilotId (as set in the EFB settings).',
     ]),
+    color: Colors.Red,
 });
 
 export const simbriefdata: CommandDefinition = {

--- a/src/commands/utils/simbriefdata.ts
+++ b/src/commands/utils/simbriefdata.ts
@@ -47,7 +47,7 @@ const simbriefdatarequestEmbed = makeEmbed({
 const pilotIdNotReplacedEmbed = makeEmbed({
     title: 'FlyByWire Support | SimBrief Data Input Error',
     description: makeLines([
-        'Please replace the *<pilotId>* in the used command with your simbrief pilotId (as set in the EFB settings).',
+        'Please replace the *<pilotId>* in the provided command with your simbrief pilotId (as set in the EFB settings).',
     ]),
     color: Colors.Red,
 });

--- a/src/commands/utils/simbriefdata.ts
+++ b/src/commands/utils/simbriefdata.ts
@@ -5,11 +5,13 @@ import { CommandCategory } from '../../constants';
 import { CommandDefinition, replyWithEmbed } from '../../lib/command';
 import { makeEmbed, makeLines } from '../../lib/embed';
 
+const FBW_AIRFRAME_ID = '337364_1631550522735';
+
 const simbriefEmded = (flightplan) => makeEmbed({
     title: 'SimBrief Data',
     description: makeLines([
         `**Generated at**: ${moment(flightplan.params.time_generated * 1000).format('DD.MM.YYYY, HH:mm:ss')}`,
-        `**AirFrame**: ${flightplan.aircraft.name} ${flightplan.aircraft.internal_id}`,
+        `**AirFrame**: ${flightplan.aircraft.name} ${flightplan.aircraft.internal_id} ${(flightplan.aircraft.internal_id === FBW_AIRFRAME_ID) ? '(provided by FBW)' : ''}`,
         `**AIRAC Cycle**: ${flightplan.params.airac}`,
         `**Origin**: ${flightplan.origin.icao_code}`,
         `**Destination**: ${flightplan.destination.icao_code}`,
@@ -21,7 +23,7 @@ const simbriefEmded = (flightplan) => makeEmbed({
 const simbriefIdMismatchEmbed = (enteredId, flightplanId) => makeEmbed({
     title: 'SimBrief Data',
     description: makeLines([
-        `Entered userId ${enteredId} and returned userId ${flightplanId} don't match. The userId might be used as username by someone else.`,
+        `Entered pilotId ${enteredId} and returned pilotId ${flightplanId} don't match. The pilotId might be used as username by someone else.`,
     ]),
 });
 
@@ -35,10 +37,17 @@ const simbriefdatarequestEmbed = makeEmbed({
     title: 'FlyByWire Support | SimBrief Data Request',
     description: makeLines([
         'To evaluate your problem we kindly ask you to enter the following bot command into a new message.',
-        '```.simbriefdata <userId>```',
-        'Replace <userId> incl. the brackets with your simbrief userId or userName. The Bot will read your last generated flight plan and display some details about it incl. the route.',
+        '```.simbriefdata <pilotId>```',
+        'Replace <pilotId> incl. the brackets with your simbrief pilotId or userName (as set in the EFB settings). The Bot will read your last generated flight plan and display some details about it incl. the route.',
         '',
-        '**Privacy notice**: If you share your userId or username it is possible to read your pilot name from the API the bot uses. This pilot name is by default your real name, but you can change it in the flight edit screen or your user profile in SimBrief. No data is stored by FlyByWire when using the command.',
+        '**Privacy notice**: If you share your pilotId or username it is possible to read your pilot name from the API the bot uses. This pilot name is by default your real name, but you can change it in the flight edit screen or your user profile in SimBrief. No data is stored by FlyByWire when using the command.',
+    ]),
+});
+
+const pilotIdNotReplacedEmbed = makeEmbed({
+    title: 'FlyByWire Support | SimBrief Data Input Error',
+    description: makeLines([
+        'Please replace the *<pilotId>* in the used command with your simbrief pilotId (as set in the EFB settings).',
     ]),
 });
 
@@ -48,9 +57,17 @@ export const simbriefdata: CommandDefinition = {
     category: CommandCategory.UTILS,
     executor: async (msg) => {
         const splitUp = msg.content.split(' ').slice(1);
-        const simbriefId = splitUp[0];
+        let simbriefId = splitUp[0];
         if (simbriefId === undefined || simbriefId === null) {
             return replyWithEmbed(msg, simbriefdatarequestEmbed);
+        }
+
+        if (simbriefId === '<pilotId>') {
+            return replyWithEmbed(msg, pilotIdNotReplacedEmbed);
+        }
+
+        if (simbriefId.startsWith('<') && simbriefId.endsWith('>')) {
+            simbriefId = simbriefId.slice(1).slice(0, -1);
         }
 
         const flightplan = await fetch(`https://www.simbrief.com/api/xml.fetcher.php?json=1&userid=${simbriefId}&username=${simbriefId}`).then((res) => res.json());


### PR DESCRIPTION
## Description

- allow simbriefId being in <>
- show an error message if command incl <pilotId> as simbriefId is just copied
- add short Text if the airframe is the one provided by FBW

## Test Results

![Screenshot 2023-07-11 213124](https://github.com/flybywiresim/discord-bot/assets/79196358/51abd91c-67d8-4cc4-b71c-6cf5250972b6)


## Discord Username

<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. --> slein15
