### PR TITLE
fix: Removing autodelete of timeout command and response, fixing bug with untimeout

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ July 2023</small>
 
+- fix: Removing auto-delete of timeout command and response, and fixing bug with untimeout (27/07/2023)
 - feat: optimize simbriefdata for input error and check for FBW airframe (11/07/2023)
 - fix: adding protection if parsing channels or roles fail and autodelete command (09/07/2023)
 - fix: adding channel based permissions for memes and some utils (08/07/2023)

--- a/src/commands/moderation/timeout.ts
+++ b/src/commands/moderation/timeout.ts
@@ -197,9 +197,13 @@ export const timeout: CommandDefinition = {
             return msg.reply('Cannot timeout a user for more than 3 weeks.');
         }
 
+        if (timeoutDuration === 0) {
+            timeoutDuration = 1; // Setting to 1ms in case an untimeout is requested
+        }
+
         return targetUser.timeout(timeoutDuration, reason).then(async () => {
-            if (timeoutDuration === 0) { // Timeout removed
-                const timeoutResponse = await msg.reply({ embeds: [unTimeoutEmbed(targetUser.user)] });
+            if (timeoutDuration === 1) { // Timeout removed
+                await msg.reply({ embeds: [unTimeoutEmbed(targetUser.user)] });
                 if (modLogsChannel) {
                     await modLogsChannel.send({ embeds: [unTimeoutModLogEmbed(msg.author, targetUser.user)] });
                 }
@@ -223,14 +227,11 @@ export const timeout: CommandDefinition = {
                         });
                     }
                 }
-                return setTimeout(() => {
-                    timeoutResponse.delete();
-                    msg.delete();
-                }, 4000);
+                return;
             }
 
             if (targetUser.isCommunicationDisabled()) { // Timeout successful
-                const timeoutResponse = await msg.reply({ embeds: [timeoutEmbed(targetUser.user, reason, timeoutArg)] });
+                await msg.reply({ embeds: [timeoutEmbed(targetUser.user, reason, timeoutArg)] });
                 try {
                     await targetUser.send({ embeds: [DMEmbed(msg.author, timeoutArg, reason, msg.guild, targetUser.communicationDisabledUntil)] });
                 } catch (e) {
@@ -268,13 +269,10 @@ export const timeout: CommandDefinition = {
                         await modLogsChannel.send({ embeds: [warnFailed] });
                     }
                 }
-                return setTimeout(() => { // Delete the command and response after 4 seconds
-                    timeoutResponse.delete();
-                    msg.delete();
-                }, 4000);
+                return;
             }
 
-            return msg.reply({ embeds: [failedTimeoutEmbed(targetUser)] }); // Timeout unsuccessful
+            await msg.reply({ embeds: [failedTimeoutEmbed(targetUser)] }); // Timeout unsuccessful
         });
     },
 };


### PR DESCRIPTION
## fix: Removing autodelete of timeout command and response, fixing bug with untimeout

## Description

Removes the autodelete of timeout command and response
Fixes a bug where timing out with 0 would not actually remove the timeout, but throw an error instead.

## Test Results

<img width="404" alt="Screenshot 2023-07-27 at 2 50 26 PM" src="https://github.com/flybywiresim/discord-bot/assets/942391/8afaffa9-eae3-40ce-a02c-d186435bb574">
<img width="392" alt="Screenshot 2023-07-27 at 2 56 32 PM" src="https://github.com/flybywiresim/discord-bot/assets/942391/5a84ce77-9967-4fc6-88fe-9b9554f2bdc5">

## Discord Username

straks
