### PR TITLE
- feat: APmodes

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ July 2024</small>
 
+- feat: New .APModes command (4/7/2024)
 - fix: update takeoff calculator and flex temp command to highlight new improvements (01/07/2024)
 
 Update <small>_ June 2024</small>

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -138,6 +138,7 @@ import { spad } from './general/spad';
 import { devLanguages } from './general/devLanguages';
 import { simbridgeDebug } from './support/simbridgeDebug';
 import { migratedCommand } from './general/migratedCommand';
+import { apmodes } from './support/apmodes';
 //import { avatar } from './utils/avatar';
 //import { ban } from './moderation/ban';
 //import { birthday } from './utils/birthday';
@@ -310,6 +311,7 @@ const commands: BaseCommandDefinition[] = [
     devLanguages,
     simbridgeDebug,
     migratedCommand,
+    apmodes,
     //avatar,
     //ban,
     //birthday,

--- a/src/commands/support/apmodes.ts
+++ b/src/commands/support/apmodes.ts
@@ -1,0 +1,19 @@
+import { MessageCommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed } from '../../lib/embed';
+
+const MANAGED_SELECTED_IMAGE = 'https://cdn.discordapp.com/attachments/1234165731319353436/1258331400709472256/New_Project_1.png?ex=6687a7f0&is=66865670&hm=462f8a417207e18117703c42295da293497dc2895f88f30d068c07f216ea5259&';
+
+export const apModesEmbed = makeEmbed({
+    title: 'Auto Pilot Modes',
+    description: 'For a detailed explanation of the different guidance modes visit our [documentation](https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/overview/#autopilot-and-flight-director-modes).',
+    image: { url: MANAGED_SELECTED_IMAGE },
+    footer: { text: 'Tip: Click the image to view in full size' },
+});
+
+export const apmodes: MessageCommandDefinition = {
+    name: ['apmodes', 'APmodes'],
+    description: 'Provides information about the Managed and Selected autopilot modes.',
+    category: CommandCategory.SUPPORT,
+    genericEmbed: apModesEmbed,
+};


### PR DESCRIPTION
## Description

This command helps people understand the difference between "Managed" & "Selected" AP modes. The user can execute the command by typing `.APmodes` OR `.apmodes`.

## Test Results
![image](https://github.com/flybywiresim/discord-bot/assets/71980142/598241db-b000-4100-b039-a805396a0ac1)

Here is the full image of the embed: 
![image](https://github.com/flybywiresim/discord-bot/assets/71980142/2d872f5a-f2b2-4e7f-8054-5c30fc3ad01a)



## Discord Username

LunakisLeaks
