### PR TITLE
feat(a380command): Add a command that gives users the A380X's release date

### DIFF
--- a/src/commands/general/a380.ts
+++ b/src/commands/general/a380.ts
@@ -1,0 +1,15 @@
+import { MessageCommandDefinition } from '../../lib/command';
+import { CommandCategory } from '../../constants';
+import { makeEmbed } from '../../lib/embed';
+
+const a380Embed = makeEmbed({
+    title: 'When is the A380X releasing?',
+    description: 'The A380X is releasing on the 31st of October, 2024.',
+});
+
+export const a380: MessageCommandDefinition = {
+    name: 'a380',
+    description: "The A380X's release date",
+    category: CommandCategory.GENERAL,
+    genericEmbed: a380Embed,
+};


### PR DESCRIPTION
<!-- ## Title -->
Add a command that gives users the A380X's release date

## Description
I have added a command that will give the A380X's release date when users type ".a380"

## Testing
Standby for screenshots
## Discord Username
Capt. Crystal